### PR TITLE
[Bug]: HTML Export matplotlib buttons do not work

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -373,7 +373,8 @@ body {
 .ocode-export hr { border: none; border-top: 1px solid var(--background-modifier-border, #ddd); margin: 2em 0; }
 /* Static export: drop interactive affordances. */
 .ocode-export .ocode-pill, .ocode-export .ocode-btn-group,
-.ocode-export .ocode-input-bar, .ocode-export .edit-block-button { display: none !important; }
+.ocode-export .ocode-input-bar, .ocode-export .edit-block-button,
+.ocode-export .ocode-output-toolbar { display: none !important; }
 @media print {
   /* printToPDF runs with margins:0 so the themed background bleeds to the paper
      edge. (Electron's printToPDF, unlike Chrome's CLI, does NOT paint the root

--- a/src/main.ts
+++ b/src/main.ts
@@ -2381,7 +2381,7 @@ __ocode_emit_vars
     const drop = [
       ".markdown-preview-pusher", ".mod-header", ".mod-footer",
       ".ocode-btn-group", ".ocode-pill", ".ocode-input-bar",
-      ".edit-block-button", ".collapse-indicator",
+      ".edit-block-button", ".collapse-indicator", ".ocode-output-toolbar",
     ];
     for (const sel of drop) {
       for (const el of Array.from(root.querySelectorAll(sel))) el.remove();


### PR DESCRIPTION
🤖 **Autonomous PR by Claude Conductor** — review before merging.

**Priority:** medium
**Tests:** ⚠️ no test command configured
**Cost:** $0.454  •  **Turns:** 9

**Task prompt:**

> [Bug]: HTML Export matplotlib buttons do not work

### What happened?

There are buttons in the HTML export that show up but do not work.

### Steps to reproduce

x

### Expected behaviour

Every button that shows up in the HTML preview should either work or be hidden.

### Screenshots / screen recordings

_No response_

### Obsidian version

1.12.7

### CodeSuite version

1.12.0

### Operating system

macOS

### Additional context

_No response_

(GitHub issue felixleopold/obsidian-code-suite#35: https://github.com/felixleopold/obsidian-code-suite/issues/35)
Implement a fix or feature that resolves this issue by editing the code. Do NOT commit, push, or open a pull request yourself — the conductor handles branching, committing and opening the PR after your changes.

---
_Generated unattended in a throwaway clone. The branch + this PR are the full blast radius._