### PR TITLE
[Bug]: CodeSuite front matter fields are not rendered properly in preview mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ code_vars:
 ---
 ```
 
+You can also write it as a list of `key = value` strings (`- threshold = 0.85`); use that form when you want `code_vars` to render in reading view, since a nested mapping shows an "unsupported property type" warning in Obsidian's Properties panel.
+
 A `vars` block in the body wins if both define the same key.
 
 </details>

--- a/docs/variables-and-execution.md
+++ b/docs/variables-and-execution.md
@@ -180,6 +180,21 @@ code_vars:
 
 YAML already has types: `0.85` is a float, `true` is a bool, `null` is null. No inference needed. String values don't require quotes in YAML but you can add them for clarity.
 
+**List form (renders in reading view).** The nested mapping above can't be shown in Obsidian's reading-view Properties panel — a nested object displays an orange "unsupported property type" warning and collapses. If you want `code_vars` to render in preview, write it as a list of `key = value` strings instead:
+
+```yaml
+---
+code_vars:
+  - threshold = 0.85
+  - crawl_depth = 5
+  - base_url = "https://api.example.com/v1"
+  - download = true
+  - optional = null
+---
+```
+
+Each item uses the same `key = value` (or `key: value`) grammar as a `vars` block, including `:type` hints (`port:int = 8080`). Obsidian renders a plain list of strings as a normal List property, so it shows up in reading view without a warning.
+
 **Precedence:** a `vars` block in the note body overrides the frontmatter value for the same key.
 
 ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ import {
   type VarEntry,
   parseVarsSource,
   inferVarValue,
+  isValidIdent,
   fromJsValue,
   toJs,
   toDisplay,
@@ -3090,8 +3091,8 @@ __ocode_emit_vars
   private applyFrontmatterVars(ctx: MarkdownPostProcessorContext): void {
     const fm = ctx.frontmatter as Record<string, unknown> | undefined;
     if (!fm) return;
-    const raw = fm["code_vars"];
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+    const entries = this.collectFrontmatterVars(fm["code_vars"]);
+    if (!entries.length) return;
     const notePath = ctx.sourcePath;
     if (!notePath) return;
 
@@ -3101,14 +3102,56 @@ __ocode_emit_vars
     const seedStore = this.noteVarsBlockStore.get(notePath)!;
 
     let changed = false;
-    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-      if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) continue;
-      const typed = fromJsValue(v);
+    for (const [k, typed] of entries) {
       // Only seed if not already present (block-level vars take precedence).
       if (!(k in seedStore)) { seedStore[k] = typed; changed = true; }
       if (!(k in varStore))  { varStore[k]  = toDisplay(typed); changed = true; }
     }
     if (changed) this.updateInlineVarRefs(notePath, varStore);
+  }
+
+  /**
+   * Normalise a `code_vars:` frontmatter value into typed name/value pairs,
+   * accepting both shapes a user can write:
+   *
+   *   code_vars:               code_vars:
+   *     threshold: 0.85          - threshold = 0.85
+   *     base_url: "https://…"    - base_url = https://…
+   *
+   * The mapping form is concise, but a nested object can't be displayed in
+   * Obsidian's reading-view Properties panel — it shows an orange
+   * "unsupported property type" warning and collapses (#34). The list form is
+   * a plain list of strings, which Obsidian renders as a normal List property,
+   * so notes that need their `code_vars` to show up in preview can use it.
+   * Each list item is parsed with the same `key = value` / `key: value`
+   * grammar as a `vars` block (type hints included); a list item that is
+   * itself a single-key mapping is accepted too.
+   */
+  private collectFrontmatterVars(raw: unknown): Array<[string, VarValue]> {
+    const out: Array<[string, VarValue]> = [];
+    if (!raw || typeof raw !== "object") return out;
+
+    if (Array.isArray(raw)) {
+      const lines: string[] = [];
+      for (const item of raw) {
+        if (typeof item === "string") {
+          lines.push(item);
+        } else if (item && typeof item === "object" && !Array.isArray(item)) {
+          for (const [k, v] of Object.entries(item as Record<string, unknown>)) {
+            if (isValidIdent(k)) out.push([k, fromJsValue(v)]);
+          }
+        }
+      }
+      if (lines.length) {
+        for (const e of parseVarsSource(lines.join("\n"))) out.push([e.name, e.value]);
+      }
+      return out;
+    }
+
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (isValidIdent(k)) out.push([k, fromJsValue(v)]);
+    }
+    return out;
   }
 
   /**


### PR DESCRIPTION
🤖 **Autonomous PR by Claude Conductor** — review before merging.

**Priority:** medium
**Tests:** ⚠️ no test command configured
**Cost:** $1.369  •  **Turns:** 27

**Task prompt:**

> [Bug]: CodeSuite front matter fields are not rendered properly in preview mode.

### What happened?

They are defined correctly in edit mode, but do not display properly in preview mode; instead, they show an orange warning and appear collapsed.

### Steps to reproduce

Try it.

### Expected behaviour

Should render either as a list or as a dictionary.

### Screenshots / screen recordings

_No response_

### Obsidian version

11.12.7

### CodeSuite version

1.12.0

### Operating system

macOS

### Additional context

_No response_

(GitHub issue felixleopold/obsidian-code-suite#34: https://github.com/felixleopold/obsidian-code-suite/issues/34)
Implement a fix or feature that resolves this issue by editing the code. Do NOT commit, push, or open a pull request yourself — the conductor handles branching, committing and opening the PR after your changes.

---
_Generated unattended in a throwaway clone. The branch + this PR are the full blast radius._