### PR TITLE
Add configurable fenced-code passthrough languages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,16 @@ Imported themes are saved in plugin settings and appear in the theme picker imme
 
 ---
 
+## Languages
+
+### Additional passthrough languages
+
+Enter one fenced-code language per line for CodeSuite to leave untouched in both Live Preview and reading view. This lets Obsidian or another plugin render those blocks. Entries are trimmed and lowercased automatically.
+
+`base`, `d2`, and `vid` are included by default for compatibility with Obsidian Bases, D2, and the Thumbnails plugin. CodeSuite always passes through `mermaid`, `dataview`, `dataviewjs`, and `query`; those built-in entries do not need to be added to the setting.
+
+---
+
 ## Code Execution
 
 ### Enable code execution

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
   type CodePluginSettings,
   DEFAULT_SETTINGS,
   BUNDLED_THEMES,
+  parsePassthroughLanguages,
 } from "./settings";
 import { CodeFileView, CODE_FILE_VIEW_TYPE } from "./code-file-view";
 import { buildFigureEl } from "./output-view";
@@ -867,10 +868,20 @@ export default class CodePlugin extends Plugin {
     const raw = (await this.loadData()) as Partial<CodePluginSettings> | null;
     this._isFreshInstall = raw == null;
     this.settings = Object.assign({}, DEFAULT_SETTINGS, raw ?? {});
+    this.settings.additionalPassthroughLanguages = parsePassthroughLanguages(
+      this.settings.additionalPassthroughLanguages
+    ).join("\n");
   }
 
   async saveSettings() {
     await this.saveData(this.settings);
+  }
+
+  private passthroughLanguages(): Set<string> {
+    return new Set([
+      ...PASSTHROUGH_LANGS,
+      ...parsePassthroughLanguages(this.settings.additionalPassthroughLanguages),
+    ]);
   }
 
   async refreshHighlighter() {
@@ -1147,6 +1158,7 @@ export default class CodePlugin extends Plugin {
 
       const liveKeys = new Set<string>();
       const items: { from: number; to: number; deco: Decoration }[] = [];
+      const passthroughLanguages = this.passthroughLanguages();
 
       // ─── Fenced code blocks (and ```vars) ───
       // Hash of the most recent non-baked block, so a baked-output block can tell
@@ -1154,7 +1166,7 @@ export default class CodePlugin extends Plugin {
       let prevCodeHash: string | null = null;
       for (const block of scanFencedBlocks(doc)) {
         const rawLang = (block.lang || "").toLowerCase();
-        if (PASSTHROUGH_LANGS.has(rawLang)) continue;
+        if (passthroughLanguages.has(rawLang)) continue;
 
         // Baked-output blocks (opt-in): render the saved output as a read-only
         // panel widget. Leave prevCodeHash untouched so the staleness check keys
@@ -1490,6 +1502,7 @@ export default class CodePlugin extends Plugin {
    */
   private parseRunAllPlan(source: string): RunAllEntry[] {
     const entries: RunAllEntry[] = [];
+    const passthroughLanguages = this.passthroughLanguages();
     const lines = source.split("\n");
     const embedRe = /^!\[\[([^\]|]+?\.[a-zA-Z0-9]+)(?:\|[^\]]*)?\]\]$/;
     let i = 0;
@@ -1528,7 +1541,7 @@ export default class CodePlugin extends Plugin {
       }
       // Apply the same filters as processCodeBlocks: skip passthrough langs,
       // vars blocks, and non-executable languages (those don't get Run buttons).
-      if (PASSTHROUGH_LANGS.has(rawLang) || rawLang === "vars") continue;
+      if (passthroughLanguages.has(rawLang) || rawLang === "vars") continue;
       const resolvedLang = this.highlighter.resolveLanguage(rawLang);
       if (!isExecutable(resolvedLang)) continue;
       // Dedent like the markdown renderer so the hash matches the rendered code.
@@ -2883,6 +2896,7 @@ __ocode_emit_vars
     // closing fence; otherwise `fenceInfoStrings[bi]` becomes off-by-one as
     // soon as the section contains more than one code block.
     const fenceInfoStrings: string[] = [];
+    const passthroughLanguages = this.passthroughLanguages();
     const sectionInfo = ctx.getSectionInfo(el);
     if (sectionInfo) {
       // sectionInfo.text is the WHOLE file, not just this section — scanning
@@ -2929,7 +2943,7 @@ __ocode_emit_vars
 
       // Skip languages that Obsidian (or its plugins) render natively — let
       // them handle the block so we don't swallow their output.
-      if (PASSTHROUGH_LANGS.has(rawLang.toLowerCase())) continue;
+      if (passthroughLanguages.has(rawLang.toLowerCase())) continue;
 
       // `vars` blocks define note-scoped variables inline — parse and store immediately.
       if (rawLang.toLowerCase() === "vars") {

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab, Setting, Notice, setIcon, Platform } from "obsidian";
 import type CodePlugin from "./main";
-import { BUNDLED_THEMES, type CustomTheme, type ExecutionCwdMode } from "./settings";
+import { BUNDLED_THEMES, parsePassthroughLanguages, type CustomTheme, type ExecutionCwdMode } from "./settings";
 
 type TabId = "appearance" | "execution" | "languages" | "files" | "advanced";
 
@@ -552,6 +552,25 @@ export class CodeSettingTab extends PluginSettingTab {
   private renderLanguages(containerEl: HTMLElement): void {
     const aboutDiv = containerEl.createDiv({ cls: "ocode-settings-about" });
     aboutDiv.createEl("p").textContent = "Interpreter paths and per-language options. Leave a path blank to use the system default.";
+
+    new Setting(containerEl).setName("Code block passthrough").setHeading();
+
+    const passthroughSetting = new Setting(containerEl)
+      .setName("Additional passthrough languages")
+      .addTextArea((t) => {
+        t.inputEl["placeholder"] = "base\nd2\nvid";
+        t.setValue(this.plugin.settings.additionalPassthroughLanguages);
+        t.inputEl.rows = 4;
+        t.inputEl.cols = 40;
+        t.onChange(async (v) => {
+          this.plugin.settings.additionalPassthroughLanguages = parsePassthroughLanguages(v).join("\n");
+          await this.plugin.saveSettings();
+          this.plugin.refreshRenderedBlocks();
+        });
+      });
+    passthroughSetting.descEl["textContent"] = "Fenced-code languages CodeSuite leaves untouched for Obsidian or another plugin to render, one per line. Entries are trimmed and lowercased. Defaults: base, d2, and vid. Built-in passthrough: mermaid, dataview, dataviewjs, and query.";
+
+    new Setting(containerEl).setName("Interpreters").setHeading();
 
     new Setting(containerEl)
       .setName("Python path")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -114,6 +114,11 @@ export interface CodePluginSettings {
   demoThemeCycle?: boolean;
   showLineNumbers: boolean;
   showLanguageLabel: boolean;
+  /**
+   * Newline-separated fenced-code languages CodeSuite leaves for Obsidian or
+   * another plugin to render. Built-in passthrough languages are kept separate.
+   */
+  additionalPassthroughLanguages: string;
   /** Soft-wrap long lines in reading view instead of showing a horizontal scrollbar. */
   wrapCodeInReadingView: boolean;
   enableExecution: boolean;
@@ -281,6 +286,7 @@ export const DEFAULT_SETTINGS: CodePluginSettings = {
   lightAutoTheme: "github-light",
   showLineNumbers: true,
   showLanguageLabel: true,
+  additionalPassthroughLanguages: "base\nd2\nvid",
   wrapCodeInReadingView: true,
   enableExecution: true,
   renderEmbeddedFiles: true,
@@ -323,6 +329,16 @@ export const DEFAULT_SETTINGS: CodePluginSettings = {
   exportSinglePage: false,
   exportIncludeTitle: false,
 };
+
+/** Normalize newline-separated fenced-code language names from settings. */
+export function parsePassthroughLanguages(languages: string): string[] {
+  return Array.from(new Set(
+    languages
+      .split("\n")
+      .map((language) => language.trim().toLowerCase())
+      .filter(Boolean)
+  ));
+}
 
 /** Parse extra env string (KEY=VALUE per line) into Record */
 export function parseExtraEnv(envStr: string): Record<string, string> {


### PR DESCRIPTION
## Summary
- add an Additional passthrough languages setting with normalized newline-separated entries
- keep mermaid, dataview, dataviewjs, and query built in while defaulting base, d2, and vid for known compatibility conflicts
- apply the combined passthrough set in Live Preview, reading view, and Run All
- document the setting and defaults; omit tldraw because its fenced language is unverified

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/`
- `git diff --check`

Closes #46
Closes #45