### PR TITLE
feat(shared-context): enable non-local variables in JavaScript blocks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ import {
   toShellScalar,
   pythonSeedLine,
   shellSeedLine,
+  javascriptSeedLine,
   parseTableDirective,
   headerLooksLikeVars,
   buildTableVars,
@@ -1392,7 +1393,7 @@ export default class CodePlugin extends Plugin {
   // ─── Shared Execution Context ────────────────────────────────
 
   /** Languages that support shared context (prepend-and-suppress approach). */
-  private static readonly SHARED_CTX_LANGS = new Set(["python", "bash", "zsh", "shell"]);
+  private static readonly SHARED_CTX_LANGS = new Set(["python", "bash", "zsh", "shell", "javascript"]);
 
   /** Clear accumulated context, var store, and inline var DOM state for a note. */
   private clearNoteSession(notePath: string): void {
@@ -1952,10 +1953,14 @@ export default class CodePlugin extends Plugin {
       m && Object.keys(m).length ? Object.entries(m).map(([k, v]) => pythonSeedLine(k, v)).join("\n") + "\n" : "";
     const renderSh = (m?: Record<string, VarValue>) =>
       m && Object.keys(m).length ? Object.entries(m).map(([k, v]) => shellSeedLine(k, v)).join("\n") + "\n" : "";
+    const renderJs = (m?: Record<string, VarValue>) =>
+      m && Object.keys(m).length ? Object.entries(m).map(([k, v]) => javascriptSeedLine(k, v)).join("\n") + "\n" : "";
     const pythonSeed = renderPy(preSeeds);
     const pythonPost = renderPy(postSeeds);
     const bashSeed   = renderSh(preSeeds);
     const bashPost   = renderSh(postSeeds);
+    const jsSeed     = renderJs(preSeeds);
+    const jsPost     = renderJs(postSeeds);
 
     if (lang === "python") {
       // Fast path: only seed vars, no accumulated blocks
@@ -2035,6 +2040,29 @@ export default class CodePlugin extends Plugin {
         `${accum}\n` +
         `exec 1>&3 2>&4 0<&5 3>&- 4>&- 5<&- 6<&-\n\n` +
         `${bashPost}` +
+        `${currentBlock}`
+      );
+    }
+
+    if (lang === "javascript") {
+      // Fast path: only seed vars, no accumulated blocks
+      if (!accum.trim()) return jsSeed + jsPost + currentBlock;
+
+      // Seed vars (pre), replay prior blocks with output suppressed, then
+      // seed cross-language vars (post) so they win over same-language values.
+      // var declarations land on globalThis in Node so user code sees them.
+      return (
+        `${jsSeed}` +
+        `var __ocode_prev_out = process.stdout.write, __ocode_prev_err = process.stderr.write;\n` +
+        `process.stdout.write = function() { return true; };\n` +
+        `process.stderr.write = function() { return true; };\n` +
+        `try {\n` +
+        `  ${accum}\n` +
+        `} finally {\n` +
+        `  process.stdout.write = __ocode_prev_out;\n` +
+        `  process.stderr.write = __ocode_prev_err;\n` +
+        `}\n\n` +
+        `${jsPost}` +
         `${currentBlock}`
       );
     }
@@ -2132,6 +2160,26 @@ __ocode_emit_vars() {
 }
 __ocode_emit_vars
 `;
+
+  /**
+   * JavaScript postamble: serialize all non-underscore global properties as a
+   * single `__OCODE_VARS__=<json>` line printed to stdout. `var` declarations in
+   * Node.js land on `globalThis`, making them enumerable and readable.
+   */
+  private static readonly JS_VAR_POSTAMBLE =
+    '\ntry {' +
+    '\n  var __ocode_snap = {};' +
+    '\n  for (var __k in globalThis) {' +
+    '\n    if (__k.startsWith(\'_\')) continue;' +
+    '\n    try {' +
+    '\n      var __v = globalThis[__k];' +
+    '\n      if (typeof __v === \'function\' || typeof __v === \'undefined\') continue;' +
+    '\n      __ocode_snap[__k] = JSON.parse(JSON.stringify(__v));' +
+    '\n    } catch (_e) { /* skip non-serializable */ }' +
+    '\n  }' +
+    '\n  console.log(\'\\n__OCODE_VARS__=\' + JSON.stringify(__ocode_snap));' +
+    '\n} catch (_e) {}' +
+    '\n';
 
   /**
    * Broadcast the latest var values to all matching inline `$varname` spans in
@@ -4658,6 +4706,8 @@ __ocode_emit_vars
         execCode = execCode + CodePlugin.BASH_VAR_POSTAMBLE;
       } else if (lang === "zsh") {
         execCode = execCode + CodePlugin.ZSH_VAR_POSTAMBLE;
+      } else if (lang === "javascript") {
+        execCode = execCode + CodePlugin.JS_VAR_POSTAMBLE;
       }
     }
 

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -167,6 +167,23 @@ export function toPython(v: VarValue): string {
   }
 }
 
+/** Render a typed value as a JavaScript literal (`5`, `true`, `"x"`, `[...]`). */
+export function toJavaScript(v: VarValue): string {
+  switch (v.kind) {
+    case "string": return JSON.stringify(v.value);
+    case "int": return v.raw;
+    case "float": return v.raw;
+    case "bool": return v.value ? "true" : "false";
+    case "null": return "null";
+    case "json": return JSON.stringify(v.value);
+  }
+}
+
+/** A single JavaScript seed-assignment line for a typed value. */
+export function javascriptSeedLine(name: string, v: VarValue): string {
+  return `var ${name} = ${toJavaScript(v)};`;
+}
+
 /** Render a typed value as the *unquoted* scalar a shell variable should hold.
  *  Shells are stringly typed; structured values become a JSON string. */
 export function toShellScalar(v: VarValue): string {


### PR DESCRIPTION
Fixes #54

Adds JavaScript to the shared-context language set so JS code blocks get variable injection (from `vars` blocks, `code_vars:` frontmatter, and cross-language runtime values).

**Changes:**

- **`src/vars.ts`**: add `toJavaScript()` and `javascriptSeedLine()` for rendering typed values as JS literals (`var X = value;`)
- **`src/main.ts`**:
  - Add `"javascript"` to `SHARED_CTX_LANGS`
  - Add JS branch in `buildSharedContextCode`: seed vars as `var` declarations, replay prior JS blocks with stdout/stderr suppressed, inject cross-language post-seeds
  - Add `JS_VAR_POSTAMBLE`: walks `globalThis` to capture runtime non-function properties as `__OCODE_VARS__=<json>` (same pattern as Python/Bash/Zsh)
  - Wire JS postamble into the run path

**No new dependencies.**

**Testing:**
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (6 pass, 0 fail, 2 skipped)
- [x] TypeScript strict
- [x] Manual verification in Obsidian with a `vars` block + JS code block — non-local variables are available