### PR TITLE
Fix TypeScript execution with a custom Node installation

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -6,6 +6,7 @@ const esbuild = require("esbuild");
 
 const testDir = mkdtempSync(join(tmpdir(), "code-suite-tests-"));
 const testBundles = [
+  join(testDir, "executor.test.cjs"),
   join(testDir, "python-graphs.test.cjs"),
   join(testDir, "matlab-session.test.cjs"),
   join(testDir, "shared-context.test.cjs"),
@@ -15,6 +16,7 @@ let exitCode = 1;
 try {
   esbuild.buildSync({
     entryPoints: [
+      "tests/executor.test.ts",
       "tests/python-graphs.test.ts",
       "tests/matlab-session.test.ts",
       "tests/shared-context.test.ts",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -220,8 +220,8 @@ export function startExecution(
   let cmd = runtime.cmd;
   if (lang === "python" && settings.pythonPath) {
     cmd = settings.pythonPath;
-  } else if ((lang === "javascript" || lang === "typescript") && settings.nodePath) {
-    cmd = lang === "javascript" ? settings.nodePath : runtime.cmd;
+  } else if (lang === "javascript" && settings.nodePath) {
+    cmd = settings.nodePath;
   } else if (lang === "bash" && settings.bashPath) {
     cmd = settings.bashPath;
   } else if (lang === "zsh" && settings.zshPath) {
@@ -259,6 +259,11 @@ export function startExecution(
       env["VIRTUAL_ENV"] = venvDir;
       env["PATH"] = venvBin + path.delimiter + (env["PATH"] || "");
     }
+  }
+
+  // npx and its /usr/bin/env node launcher must use the configured Node installation.
+  if ((lang === "javascript" || lang === "typescript") && settings.nodePath) {
+    env["PATH"] = path.dirname(settings.nodePath) + path.delimiter + (env["PATH"] || "");
   }
 
   // On Windows, WSL shells can't resolve the Windows temp path we just wrote
@@ -353,9 +358,11 @@ export function startExecution(
     proc.on("error", (err: Error) => {
       window.clearTimeout(timer);
       try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* cleanup is best-effort */ }
+      const message = `Failed to run ${cmd}: ${err.message}\nMake sure ${cmd} is installed and in your PATH.`;
+      callbacks?.onStderr?.(message);
       resolve({
         stdout: "",
-        stderr: `Failed to run ${cmd}: ${err.message}\nMake sure ${cmd} is installed and in your PATH.`,
+        stderr: message,
         exitCode: 1, killed: false, cancelled: false, figures: [],
       });
     });

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { startExecution } from "../src/executor";
+import { DEFAULT_SETTINGS } from "../src/settings";
+
+// Exclude the host's Homebrew paths to model a GUI session with no system Node.
+Object.assign(globalThis, {
+  window: {
+    require: (id: string): unknown => id === "os" ? { ...os, platform: () => "linux" } : require(id),
+    setTimeout,
+    clearTimeout,
+  },
+});
+
+test("TypeScript finds npx and its Node interpreter beside the configured nodePath", {
+  skip: process.platform === "win32",
+}, async () => {
+  const bin = mkdtempSync(join(os.tmpdir(), "code-suite-node-"));
+  try {
+    symlinkSync(process.execPath, join(bin, "node"));
+    // A local launcher verifies both npx lookup and its /usr/bin/env node shebang.
+    writeFileSync(join(bin, "npx"), `#!/usr/bin/env node
+if (process.argv[2] !== "tsx" || !process.argv[3].endsWith(".ts")) process.exit(2);
+console.log("configured Node installation");
+`, { mode: 0o755 });
+    const result = await startExecution("const x: number = 42\nconsole.log(x)", "typescript", {
+      ...DEFAULT_SETTINGS,
+      nodePath: join(bin, "node"),
+      extraEnv: "PATH=/usr/bin:/bin",
+    }).promise;
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(result.stdout, "configured Node installation\n");
+  } finally {
+    rmSync(bin, { recursive: true, force: true });
+  }
+});
+
+test("process launch failures reach the output callback", async () => {
+  const dir = mkdtempSync(join(os.tmpdir(), "code-suite-missing-node-"));
+  try {
+    let displayedError = "";
+    const result = await startExecution("console.log(42)", "javascript", {
+      ...DEFAULT_SETTINGS,
+      nodePath: join(dir, "missing-node"),
+    }, { onStderr: (data) => { displayedError += data; } }).promise;
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /Failed to run .*missing-node/);
+    assert.equal(displayedError, result.stderr);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
TypeScript blocks ignored the configured Node installation when finding `npx`. With a GUI PATH that excludes an nvm installation, JavaScript ran successfully but TypeScript failed with `spawn npx ENOENT`. The launch error also never reached the output callback, leaving an empty output panel.

Prepend the configured Node directory to PATH for JavaScript and TypeScript execution, and forward process launch errors to the output callback. Fixes #60.

Validation: reproduced the exact snippet through the real executor with a restricted PATH, then verified it prints `42` and exits 0 after the fix using real `npx tsx`. Both focused regression tests, `pnpm exec tsc --noEmit`, and `pnpm lint` pass. No live Obsidian installation was changed.
