### PR TITLE
Add per-block formatting and inline code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ Powered by [Shiki](https://shiki.style/) — the exact same engine VS Code uses 
 - **Editor highlighting** — full token colors in Live Preview and Source mode via a CodeMirror 6 ViewPlugin, not just in Reading view
 - **Full chrome in Live Preview** — code blocks and `![[file.py]]` embeds render with the same header, Run/Copy buttons, live output, line numbers, and collapse as Reading view. The block your cursor is in reveals its raw source for editing; every other block shows the rendered chrome, with running output preserved as you move around
 
+
+### Per-block formatting
+
+Add space-separated attributes after the language on the opening fence:
+
+````md
+```python title="data_pipeline.py" {3, 7-10} showLineNumbers static
+# Highlighted code, with no Run button
+```
+````
+
+| Attribute | Effect |
+|---|---|
+| `static` | Keep syntax colors and block styling, disable Run and exclude the block from Run All |
+| `title="My Script.py"` | Show a title in the header, preserving spaces and case |
+| `showLineNumbers` / `hideLineNumbers` | Override the global line-number setting |
+| `{1, 5-10}` | Highlight the specified lines, numbered from 1 |
+| `ins={3}` / `del={7-10}` | Highlight inserted lines green or deleted lines red |
+| `collapse` | Start the block collapsed |
+
+Boolean options accept `=true` or `=false`. `ln=true` / `ln:false` are aliases for line numbering, and `fold=true` / `fold:false` control collapse. Existing `collapsed` and `expanded` flags still work. Per-block values override the global defaults; `static=false` makes a block runnable when **Static blocks by default** is enabled, provided execution is enabled globally. Static HTML blocks also suppress live previews.
+
+Titles and initial collapse apply in Reading View and Live Preview. Line backgrounds and numbering also appear while editing source. A `diff` block automatically colors `+` and `-` lines, excluding `+++` / `---` file headers. Explicit line ranges take precedence, with deletion over insertion over ordinary highlighting. Invalid range entries are ignored.
+
+Ordinary inline code receives stronger styling, configurable with **Enhanced inline code styling**. Add a language prefix for syntax colors, for example `` `{python} result = df.groupby("region").sum()` ``. Reading View hides a recognized prefix; the editor retains it for editing and highlights single-line spans. Unknown prefixes and existing `` `$variable` `` references retain their meaning. **Inline syntax highlighting** controls language-aware coloring separately.
+
+Inspired by [mProjectsCode’s Shiki Highlighter](https://github.com/mProjectsCode/obsidian-shiki-plugin), [Expressive Code](https://expressive-code.com/) by Hippo, and [Codeblock Customizer](https://github.com/mugiwara85/CodeblockCustomizer).
+
 ---
 
 <a id="run"></a>
@@ -298,9 +326,7 @@ Open **Settings → CodeSuite** — organized into **Appearance**, **Execution**
 
 Track progress or vote on the linked GitHub issues.
 
-| # | Feature | Issue |
-|---|---------|-------|
-| 1 | **Per-block code formatting** — line highlighting `{1,5-10}`, diff highlighting `ins`/`del`, per-block titles, `showLineNumbers` override, and inline code syntax highlighting | [#13](https://github.com/felixleopold/obsidian-code-suite/issues/13) |
+Per-block formatting and inline highlighting from [#13](https://github.com/felixleopold/obsidian-code-suite/issues/13) are implemented for the next release.
 
 **Recent releases**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,9 @@ Imported themes are saved in plugin settings and appear in the theme picker imme
 
 | Setting | Description |
 |---|---|
-| **Line numbers** | Show or hide line numbers in reading view. Does not affect editor mode. |
+| **Line numbers** | Show or hide line numbers in rendered blocks and editable source. Override per block with `showLineNumbers`, `hideLineNumbers`, or `ln=true` / `ln=false`. |
+| **Enhanced inline code styling** *(on by default)* | Give ordinary inline code a stronger background, border, and spacing. |
+| **Inline syntax highlighting** *(on by default)* | Color language-prefixed inline code, such as `` `{python} sum(values)` ``. Known prefixes are hidden in Reading View and remain editable in source. |
 | **Language label** | Show or hide the language name in the header bar of each code block. |
 | **Wide code blocks** | Allow code blocks to extend beyond the normal note content width. Useful for wide tables or long output lines. |
 | **Soft-wrap long lines** *(on by default)* | Wrap long lines in reading view instead of showing a horizontal scrollbar, matching the editor's behaviour. Turn off to restore horizontal scrolling. |
@@ -50,6 +52,9 @@ Enter one fenced-code language per line for CodeSuite to leave untouched in both
 
 ### Enable code execution
 Show the Run button on supported language blocks. Disable to use CodeSuite as a syntax-highlighting-only plugin. Desktop only — no effect on mobile.
+
+### Static blocks by default *(off by default)*
+Keep fenced blocks highlighted with no Run controls or Run All participation. Set `static=false` on a fence to make that block runnable, or `static` to disable execution for one block with this setting off. Static HTML blocks suppress live previews. Embedded code files keep their existing execution behavior.
 
 ### Show clear-session button *(on by default)*
 Show the **Clear execution session** button in the note header bar. Turn it off to declutter the tab bar — the **Clear execution session for this note** command still works from the command palette. Desktop only; the button is never shown on mobile.
@@ -177,7 +182,7 @@ Absolute path to a `.env` file on disk. Variables from this file are loaded into
 |---|---|
 | **Render embedded code files** | Replace Obsidian's default plain-text rendering of `![[file.py]]` embeds with fully syntax-highlighted, interactive CodeSuite blocks. |
 | **Collapse embedded files** | Start all embedded file blocks in the collapsed state. The header shows filename and line count; click to expand. |
-| **Collapse code blocks by default** | Every code block is always collapsible — click its header to fold/unfold. This setting only chooses the initial state (collapsed vs. expanded) in Reading view and Live Preview. Per-block `collapsed`/`expanded` fence flags override it. |
+| **Collapse code blocks by default** | Every code block is always collapsible — click its header to fold/unfold. This setting only chooses the initial state (collapsed vs. expanded) in Reading view and Live Preview. Per-block `collapse`, `collapsed`, `expanded`, and `fold=true` / `fold=false` fence flags override it. |
 
 ---
 

--- a/examples/formatting.md
+++ b/examples/formatting.md
@@ -1,0 +1,42 @@
+# Per-block and inline formatting
+
+Ordinary inline code: `result`. Language-aware inline code: `{python} result = sum([1, 2, 3])`.
+
+This static block has a title, a numbered gutter, and all three line backgrounds:
+
+```python title="Data Pipeline.py" static showLineNumbers {1} ins={2} del={3}
+values = [1, 2, 3]
+result = sum(values)
+print("Old output")
+print(result)
+```
+
+This block starts collapsed and overrides the global line-number setting:
+
+```javascript title="Folded example" fold=true ln=false static
+const message = "Expand the header to see me";
+console.log(message);
+```
+
+This block remains runnable even with **Static blocks by default** enabled:
+
+```javascript title="Runnable example" static=false
+console.log("Hello from CodeSuite");
+```
+
+Diff lines receive backgrounds automatically:
+
+```diff title="Changes.diff"
+--- a/example.py
++++ b/example.py
+@@ -1,2 +1,2 @@
+-print("Old output")
++print("New output")
+ unchanged = True
+```
+
+> A quoted static block:
+>
+> ```python static title="Quoted.py"
+> print("This block should have no Run button")
+> ```

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -10,6 +10,8 @@ const testBundles = [
   join(testDir, "python-graphs.test.cjs"),
   join(testDir, "matlab-session.test.cjs"),
   join(testDir, "shared-context.test.cjs"),
+  join(testDir, "inline-code.test.cjs"),
+  join(testDir, "block-options.test.cjs"),
 ];
 let exitCode = 1;
 
@@ -20,6 +22,8 @@ try {
       "tests/python-graphs.test.ts",
       "tests/matlab-session.test.ts",
       "tests/shared-context.test.ts",
+      "tests/inline-code.test.ts",
+      "tests/block-options.test.ts",
     ],
     bundle: true,
     platform: "node",

--- a/src/block-options.ts
+++ b/src/block-options.ts
@@ -1,0 +1,128 @@
+export type LineRange = readonly [number, number];
+
+export interface BlockOptions {
+  flags: Set<string>;
+  title?: string;
+  static?: boolean;
+  showLineNumbers?: boolean;
+  collapsed?: boolean;
+  highlight: LineRange[];
+  insert: LineRange[];
+  delete: LineRange[];
+}
+
+function parseRanges(value: string): LineRange[] {
+  const ranges: LineRange[] = [];
+  if (!value.startsWith("{") || !value.endsWith("}")) return ranges;
+  for (const part of value.slice(1, -1).split(",")) {
+    const match = /^\s*(\d+)(?:\s*-\s*(\d+))?\s*$/.exec(part);
+    if (!match) continue;
+    const start = Number(match[1]);
+    const end = Number(match[2] ?? match[1]);
+    if (Number.isSafeInteger(start) && Number.isSafeInteger(end) && start > 0 && end >= start) {
+      ranges.push([start, end]);
+    }
+  }
+  return ranges;
+}
+
+/** Parse the complete info string following the fence, including its language. */
+export function parseBlockOptions(info: string): BlockOptions {
+  const options: BlockOptions = {
+    flags: new Set<string>(),
+    highlight: [],
+    insert: [],
+    delete: [],
+  };
+  // Keep quoted titles and spaced line ranges together as single attributes.
+  const attributes = info.trim().replace(/^\S+\s*/, "");
+  const tokens = attributes.match(/(?:[^\s"'{}]+|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\{[^}]*\})+/g) ?? [];
+  for (const token of tokens) {
+    if (token.startsWith("{")) {
+      options.highlight.push(...parseRanges(token));
+      continue;
+    }
+    const match = /^([^=:]+)(?:[=:](.*))?$/.exec(token);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    const value = match[2];
+    if (value === undefined) options.flags.add(key);
+    if (key === "title" && value !== undefined) {
+      const quote = value[0];
+      options.title = (quote === '"' || quote === "'") && value.endsWith(quote)
+        ? value.slice(1, -1).replace(/\\([\\"'])/g, "$1")
+        : value;
+      continue;
+    }
+    if (key === "ins" || key === "del") {
+      options[key === "ins" ? "insert" : "delete"].push(...parseRanges(value ?? ""));
+      continue;
+    }
+    const boolean = value === undefined || value.toLowerCase() === "true"
+      ? true
+      : value.toLowerCase() === "false" ? false : undefined;
+    if (boolean === undefined) continue;
+    switch (key) {
+      case "static": options.static = boolean; break;
+      case "showlinenumbers":
+      case "ln": options.showLineNumbers = boolean; break;
+      case "hidelinenumbers": options.showLineNumbers = !boolean; break;
+      case "collapse":
+      case "collapsed":
+      case "fold": options.collapsed = boolean; break;
+      case "expanded": options.collapsed = !boolean; break;
+    }
+  }
+  return options;
+}
+
+export function isStaticBlock(options: BlockOptions, defaultStatic = false): boolean {
+  return options.static ?? defaultStatic;
+}
+
+/** Source fences for matching rendered blocks without relying on DOM order. */
+export function fencedBlockInfos(source: string): { info: string; code: string; line: number }[] {
+  const blocks: { info: string; code: string; line: number }[] = [];
+  const lines = source.split("\n");
+  for (let index = 0; index < lines.length; index++) {
+    let opening = lines[index];
+    let quoteDepth = 0;
+    while (/^[ \t]*>[ \t]?/.test(opening)) {
+      opening = opening.replace(/^[ \t]*>[ \t]?/, "");
+      quoteDepth++;
+    }
+    opening = opening.replace(/^([ \t]*)(?:[-+*]|\d+[.)])([ \t]+)/, (match: string) => " ".repeat(match.length));
+    const fence = /^([ \t]*)(`{3,}|~{3,})(.*)$/.exec(opening);
+    if (!fence || (fence[2][0] === "`" && fence[3].includes("`"))) continue;
+    const line = index;
+    const content: string[] = [];
+    while (++index < lines.length) {
+      let text = lines[index];
+      for (let depth = 0; depth < quoteDepth; depth++) text = text.replace(/^[ \t]*>[ \t]?/, "");
+      const closing = /^[ \t]*(`{3,}|~{3,})[ \t]*$/.exec(text);
+      if (closing && closing[1][0] === fence[2][0] && closing[1].length >= fence[2].length) break;
+      let indent = 0;
+      while (indent < fence[1].length && (text[indent] === " " || text[indent] === "\t")) indent++;
+      content.push(text.slice(indent));
+    }
+    blocks.push({ info: fence[3].trim(), code: content.join("\n"), line });
+  }
+  return blocks;
+}
+
+export function lineHighlightClass(
+  options: BlockOptions,
+  lineNumber: number,
+  text: string,
+  lang: string,
+): string {
+  const contains = (ranges: LineRange[]) => ranges.some(([start, end]) => lineNumber >= start && lineNumber <= end);
+  if (contains(options.delete)) return "ocode-line-delete";
+  if (contains(options.insert)) return "ocode-line-insert";
+  if (contains(options.highlight)) return "ocode-line-highlight";
+  if (lang.toLowerCase() === "diff") {
+    if (text.startsWith("+") && !/^\+\+\+\s/.test(text)) return "ocode-line-insert";
+    if (text.startsWith("-") && !/^---\s/.test(text)) return "ocode-line-delete";
+  }
+  return "";
+}

--- a/src/inline-code.ts
+++ b/src/inline-code.ts
@@ -1,0 +1,243 @@
+import { Decoration, ViewPlugin } from "@codemirror/view";
+import type { DecorationSet, EditorView, ViewUpdate } from "@codemirror/view";
+import type { Range } from "@codemirror/state";
+
+export interface InlineCodeToken {
+  content: string;
+  color?: string;
+  fontStyle?: number;
+}
+
+export interface InlineCodeHighlighter {
+  resolveLanguage(raw: string): string;
+  tokenize(code: string, lang: string, theme: string): InlineCodeToken[][] | null;
+}
+
+export interface InlineCodeOptions {
+  highlighter: InlineCodeHighlighter;
+  theme: string;
+  styleInlineCode: boolean;
+  highlightInlineCode: boolean;
+}
+
+export interface LanguageInlineCode {
+  language: string;
+  code: string;
+  codeOffset: number;
+}
+
+export interface InlineCodeSpan {
+  from: number;
+  to: number;
+  markerFrom: number;
+  markerTo: number;
+  text: string;
+}
+
+const PLAIN_TEXT_LANGUAGES = new Set(["text", "txt", "plaintext", "plain"]);
+
+/** Parse CodeSuite's `{lang} code` form without deciding whether lang is known. */
+export function parseLanguageInlineCode(text: string): LanguageInlineCode | null {
+  const match = /^\{([^{}\s]+)\}[ \t]?/.exec(text);
+  if (!match) return null;
+  return {
+    language: match[1].toLowerCase(),
+    code: text.slice(match[0].length),
+    codeOffset: match[0].length,
+  };
+}
+
+function resolveInlineLanguage(
+  parsed: LanguageInlineCode,
+  highlighter: InlineCodeHighlighter,
+): string | null {
+  const resolved = highlighter.resolveLanguage(parsed.language);
+  if (resolved !== "text" || PLAIN_TEXT_LANGUAGES.has(parsed.language)) return resolved;
+  return null;
+}
+
+function applyTokenStyle(el: HTMLElement, token: InlineCodeToken): void {
+  const styles: Record<string, string> = {};
+  if (token.color) styles.color = token.color;
+  if (token.fontStyle) {
+    if (token.fontStyle & 1) styles["font-style"] = "italic";
+    if (token.fontStyle & 2) styles["font-weight"] = "bold";
+    if (token.fontStyle & 4) styles["text-decoration"] = "underline";
+  }
+  el.setCssProps(styles);
+}
+
+/** Style ordinary inline code and highlight recognized `{lang}` spans in reading view. */
+export function processInlineCode(root: HTMLElement, options: InlineCodeOptions): void {
+  for (const codeEl of Array.from(root.querySelectorAll<HTMLElement>("code"))) {
+    if (codeEl.closest("pre")) continue;
+    if (options.styleInlineCode) codeEl.addClass("ocode-inline-code");
+    if (codeEl.hasClass("ocode-var-ref")) continue;
+    if (!options.highlightInlineCode || codeEl.hasAttribute("data-ocode-inline-language")) continue;
+
+    const parsed = parseLanguageInlineCode(codeEl.textContent ?? "");
+    if (!parsed) continue;
+    const language = resolveInlineLanguage(parsed, options.highlighter);
+    if (!language) continue;
+    const tokenLines = options.highlighter.tokenize(parsed.code, language, options.theme);
+    if (!tokenLines) continue;
+
+    codeEl.textContent = "";
+    codeEl.addClass("ocode-inline-code-highlighted");
+    codeEl.setAttribute("data-ocode-inline-language", language);
+    tokenLines.forEach((line, lineIndex) => {
+      if (lineIndex > 0) codeEl.appendText("\n");
+      for (const token of line) {
+        const span = codeEl.createSpan();
+        span.textContent = token.content;
+        applyTokenStyle(span, token);
+      }
+    });
+  }
+}
+
+/** Find single-line Markdown code spans outside fenced code blocks. */
+export function scanInlineCodeSpans(source: string): InlineCodeSpan[] {
+  const spans: InlineCodeSpan[] = [];
+  let activeFence: { marker: string; length: number } | null = null;
+  let lineFrom = 0;
+
+  const isEscaped = (line: string, position: number) => {
+    let slashes = 0;
+    for (let index = position - 1; index >= 0 && line[index] === "\\"; index--) slashes++;
+    return slashes % 2 === 1;
+  };
+
+  while (lineFrom <= source.length) {
+    const newline = source.indexOf("\n", lineFrom);
+    const lineTo = newline === -1 ? source.length : newline;
+    const line = source.slice(lineFrom, lineTo);
+    // Remove quote/list containers before recognizing a fence. Arbitrary
+    // indentation is accepted after the container so nested-list fences and
+    // indented code are both safely excluded from inline decoration.
+    const containerPrefix = /^(?:(?:[ \t]*>[ \t]?)|(?:[ \t]*(?:[-+*]|\d+[.)])[ \t]+))*/.exec(line)?.[0] ?? "";
+    const rest = line.slice(containerPrefix.length);
+    const fence = /^[ \t]*(`{3,}|~{3,})(.*)$/.exec(rest);
+
+    if (activeFence) {
+      if (fence && fence[1][0] === activeFence.marker
+          && fence[1].length >= activeFence.length && !fence[2].trim()) {
+        activeFence = null;
+      }
+    } else if (fence && (fence[1][0] === "~" || !fence[2].includes("`"))) {
+      activeFence = { marker: fence[1][0], length: fence[1].length };
+    } else if (!/^(?: {4}|\t)/.test(line)) {
+      let cursor = 0;
+      while (cursor < line.length) {
+        const opening = line.indexOf("`", cursor);
+        if (opening === -1) break;
+        if (isEscaped(line, opening)) {
+          cursor = opening + 1;
+          continue;
+        }
+        let markerLength = 1;
+        while (line[opening + markerLength] === "`") markerLength++;
+
+        let closing = opening + markerLength;
+        while ((closing = line.indexOf("`", closing)) !== -1) {
+          let closingLength = 1;
+          while (line[closing + closingLength] === "`") closingLength++;
+          // Backslashes inside the span are literal and cannot escape this.
+          if (closingLength === markerLength) break;
+          closing += closingLength;
+        }
+        if (closing === -1) {
+          cursor = opening + markerLength;
+          continue;
+        }
+
+        const from = lineFrom + opening + markerLength;
+        const to = lineFrom + closing;
+        spans.push({
+          from,
+          to,
+          markerFrom: lineFrom + opening,
+          markerTo: lineFrom + closing + markerLength,
+          text: source.slice(from, to),
+        });
+        cursor = closing + markerLength;
+      }
+    }
+
+    if (newline === -1) break;
+    lineFrom = newline + 1;
+  }
+  return spans;
+}
+
+function tokenStyle(token: InlineCodeToken): string | null {
+  if (!token.color) return null;
+  let style = `color: ${token.color} !important`;
+  if (token.fontStyle) {
+    if (token.fontStyle & 1) style += "; font-style: italic";
+    if (token.fontStyle & 2) style += "; font-weight: bold";
+    if (token.fontStyle & 4) style += "; text-decoration: underline";
+  }
+  return style;
+}
+
+/** Build editor decorations for enhanced inline styling and `{lang}` token colors. */
+export function buildInlineCodeEditorExtension(getOptions: () => InlineCodeOptions) {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      private lastSignature: string;
+
+      constructor(view: EditorView) {
+        this.lastSignature = this.signature();
+        this.decorations = this.buildDecorations(view);
+      }
+
+      update(update: ViewUpdate): void {
+        const signature = this.signature();
+        if (update.docChanged || update.viewportChanged || signature !== this.lastSignature) {
+          this.lastSignature = signature;
+          this.decorations = this.buildDecorations(update.view);
+        }
+      }
+
+      private signature(): string {
+        const options = getOptions();
+        return `${options.theme}|${options.styleInlineCode}|${options.highlightInlineCode}`;
+      }
+
+      private buildDecorations(view: EditorView): DecorationSet {
+        const options = getOptions();
+        const decorations: Range<Decoration>[] = [];
+        for (const span of scanInlineCodeSpans(view.state.doc.toString())) {
+          if (options.styleInlineCode && span.markerFrom < span.markerTo) {
+            decorations.push(
+              Decoration.mark({ class: "ocode-inline-code" }).range(span.markerFrom, span.markerTo),
+            );
+          }
+          if (!options.highlightInlineCode) continue;
+
+          const parsed = parseLanguageInlineCode(span.text);
+          if (!parsed) continue;
+          const language = resolveInlineLanguage(parsed, options.highlighter);
+          if (!language) continue;
+          const tokens = options.highlighter.tokenize(parsed.code, language, options.theme)?.[0];
+          if (!tokens) continue;
+
+          let offset = span.from + parsed.codeOffset;
+          for (const token of tokens) {
+            const tokenFrom = offset;
+            const tokenTo = tokenFrom + token.content.length;
+            const style = tokenStyle(token);
+            if (style && tokenFrom < tokenTo && tokenTo <= span.to) {
+              decorations.push(Decoration.mark({ attributes: { style } }).range(tokenFrom, tokenTo));
+            }
+            offset = tokenTo;
+          }
+        }
+        return Decoration.set(decorations, true);
+      }
+    },
+    { decorations: (value) => value.decorations },
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,8 @@ import type { DecorationSet, ViewUpdate } from "@codemirror/view";
 import { RangeSetBuilder, StateField, StateEffect, Prec } from "@codemirror/state";
 import type { Extension, Text, EditorState, Range } from "@codemirror/state";
 import { Highlighter, EXT_TO_LANG } from "./highlighter";
+import { parseBlockOptions, isStaticBlock, lineHighlightClass, fencedBlockInfos, type BlockOptions } from "./block-options";
+import { processInlineCode, buildInlineCodeEditorExtension } from "./inline-code";
 import { CodeSettingTab } from "./settings-tab";
 import { startExecution, isExecutable, type RunningProcess, type OutputFigure } from "./executor";
 import {
@@ -292,15 +294,15 @@ interface FmPanelGroup {
 }
 
 /**
- * Walk an editor document and return every *closed* ```-fenced code block with
+ * Walk an editor document and return every closed fenced code block with
  * absolute positions covering the fence lines. Shared by the Shiki token-color
  * extension and the Live Preview block-widget extension so both agree on block
- * boundaries. Only backtick fences are recognized (matches the editor's
- * historical behavior); unclosed blocks are skipped so they stay editable.
+ * boundaries. Unclosed blocks are skipped so they stay editable.
  */
 function scanFencedBlocks(doc: Text): FencedBlock[] {
   const blocks: FencedBlock[] = [];
   let inBlock = false;
+  let fence = "";
   let lang = "";
   let info = "";
   let indent = "";
@@ -309,14 +311,16 @@ function scanFencedBlocks(doc: Text): FencedBlock[] {
   for (let i = 1; i <= doc.lines; i++) {
     const line = doc.line(i);
     const trimmed = line.text.trimStart();
-    if (!inBlock && trimmed.startsWith("```")) {
+    const marker = trimmed.match(/^(`{3,}|~{3,})(.*)$/);
+    if (!inBlock && marker && !(marker[1][0] === "`" && marker[2].includes("`"))) {
       inBlock = true;
-      info = trimmed.slice(3).trim();
+      fence = marker[1];
+      info = marker[2].trim();
       lang = info.split(/\s/)[0];
       indent = line.text.slice(0, line.text.length - trimmed.length);
       openFrom = line.from;
       innerLines = [];
-    } else if (inBlock && /^`{3,}\s*$/.test(trimmed)) {
+    } else if (inBlock && marker && marker[1][0] === fence[0] && marker[1].length >= fence.length && !marker[2].trim()) {
       blocks.push({
         lang,
         info,
@@ -637,13 +641,6 @@ export default class CodePlugin extends Plugin {
       activeDocument.body.addClass("ocode-wrap-code");
     }
 
-    // Mirror line-number chrome onto the raw lines Obsidian shows while a Live
-    // Preview block is being edited, so clicking in doesn't flash a gutter-less
-    // "native" block before our chrome returns.
-    if (this.settings.showLineNumbers) {
-      activeDocument.body.addClass("ocode-lp-lnum");
-    }
-
     // Apply theme CSS variables
     this.applyThemeColors();
     this.applyCodeFontSize();
@@ -677,6 +674,7 @@ export default class CodePlugin extends Plugin {
     // Editor (CM6): Shiki token colors + full block-chrome widgets (Live Preview)
     this.registerEditorExtension([
       this.buildShikiEditorExtension(),
+      buildInlineCodeEditorExtension(() => ({ highlighter: this.highlighter, ...this.settings })),
       this.buildBlockWidgetExtension(),
     ]);
 
@@ -750,6 +748,7 @@ export default class CodePlugin extends Plugin {
     this.registerMarkdownPostProcessor(
       (el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
         this.processInlineVarRefs(el, ctx);
+        processInlineCode(el, { highlighter: this.highlighter, ...this.settings });
       },
       1001
     );
@@ -898,7 +897,6 @@ export default class CodePlugin extends Plugin {
     this.highlighter.dispose();
     activeDocument.body.removeClass("ocode-wide-blocks");
     activeDocument.body.removeClass("ocode-wrap-code");
-    activeDocument.body.removeClass("ocode-lp-lnum");
     for (const doc of this._codeFontDocuments) {
       doc.body.style.removeProperty("--ocode-code-font-size");
     }
@@ -1107,6 +1105,7 @@ export default class CodePlugin extends Plugin {
     const tokenize = (code: string, lang: string, theme: string) =>
       this.highlighter.tokenize(code, lang, theme);
     const getTheme = () => this.settings.theme;
+    const getLineNumbers = () => this.settings.showLineNumbers;
 
     return ViewPlugin.fromClass(
       class {
@@ -1120,7 +1119,7 @@ export default class CodePlugin extends Plugin {
 
         update(update: ViewUpdate) {
           const currentTheme = getTheme();
-          if (update.docChanged || update.viewportChanged || currentTheme !== this.lastTheme) {
+          if (update.docChanged || update.viewportChanged || currentTheme !== this.lastTheme || update.transactions.some((tr) => tr.effects.some((e) => e.is(lpRebuildEffect)))) {
             this.lastTheme = currentTheme;
             this.decorations = this.buildDecorations(update.view);
           }
@@ -1135,9 +1134,14 @@ export default class CodePlugin extends Plugin {
           // the replace decoration covers them, so the wasted marks are harmless.
           for (const block of scanFencedBlocks(doc)) {
             if (block.innerLines.length === 0) continue;
+            const options = parseBlockOptions(block.info);
             for (let lineIdx = 0; lineIdx < block.innerLines.length; lineIdx++) {
+              const lineClass = lineHighlightClass(options, lineIdx + 1, stripFenceIndent(block.innerLines[lineIdx].text, block.indent), block.lang);
               decorations.push(Decoration.line({
-                attributes: { "data-ocode-line-number": String(lineIdx + 1) },
+                attributes: {
+                  "data-ocode-line-number": String(lineIdx + 1),
+                  class: [lineClass, (options.showLineNumbers ?? getLineNumbers()) ? "ocode-numbered-line" : ""].filter(Boolean).join(" "),
+                },
               }).range(block.innerLines[lineIdx].from));
             }
             if (!block.lang) continue;
@@ -1195,6 +1199,7 @@ export default class CodePlugin extends Plugin {
       s.showLanguageLabel,
       s.showLineNumbers,
       s.enableExecution,
+      s.staticBlocksByDefault,
       s.inlineCollapsedByDefault,
       s.collapseEmbeds,
       s.renderEmbeddedFiles,
@@ -1265,12 +1270,10 @@ export default class CodePlugin extends Plugin {
           continue;
         }
 
-        const attrs = new Set(
-          block.info.split(/\s+/).slice(1).map((w) => w.toLowerCase()).filter(Boolean)
-        );
+        const options = parseBlockOptions(block.info);
+        const attrs = options.flags;
         const forceSkip = attrs.has("skip");
-        const forceCollapsed: boolean | null =
-          attrs.has("collapsed") ? true : attrs.has("expanded") ? false : null;
+        const forceCollapsed = options.collapsed ?? null;
         const htmlPdf = this.htmlPdfState(rawLang, attrs);
 
         const isVars = rawLang === "vars";
@@ -1294,7 +1297,7 @@ export default class CodePlugin extends Plugin {
         const tmplSig = htmlTemplate ? this.frontmatterSig(notePath) : "";
         // Visual indent in editor columns, so the widget lines up with its list.
         const indentCols = this.indentColumns(block.indent, state.tabSize);
-        const key = `${this.lpBlockKey(resolvedLang, code)}\0${forceSkip}\0${forceCollapsed}\0${htmlPreview}\0${htmlPdf}\0${htmlTemplate}\0${tmplSig}\0${indentCols}\0${sig}`;
+        const key = `${block.info}\0${this.lpBlockKey(resolvedLang, code)}\0${forceSkip}\0${forceCollapsed}\0${htmlPreview}\0${htmlPdf}\0${htmlTemplate}\0${tmplSig}\0${indentCols}\0${sig}`;
         // Register the key BEFORE the cursor check so a block being edited (or
         // running) is never pruned out from under its live output / process.
         liveKeys.add(key);
@@ -1307,7 +1310,7 @@ export default class CodePlugin extends Plugin {
             const w = isVars
               ? this.buildVarsWrapper(code, notePath)
               : this.buildCodeBlockWrapper(
-                  code, resolvedLang, block.lang, undefined, notePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate,
+                  code, resolvedLang, block.lang, undefined, notePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options,
                 );
             // Indent the widget to match its list nesting (#27); ch units track
             // the indent's column width closely enough for a clear visual cue.
@@ -1630,7 +1633,8 @@ export default class CodePlugin extends Plugin {
       const infoStr   = fenceMatch[3].trim();
       const parts     = infoStr.split(/\s+/);
       const rawLang   = (parts[0] ?? "").toLowerCase();
-      const forceSkip = parts.slice(1).map((w) => w.toLowerCase()).includes("skip");
+      const options = parseBlockOptions(infoStr);
+      const forceSkip = options.flags.has("skip");
       const openLine  = i;
       // Collect block content
       const contentLines: string[] = [];
@@ -1648,7 +1652,7 @@ export default class CodePlugin extends Plugin {
       // vars blocks, and non-executable languages (those don't get Run buttons).
       if (passthroughLanguages.has(rawLang) || rawLang === "vars") continue;
       const resolvedLang = this.highlighter.resolveLanguage(rawLang);
-      if (!isExecutable(resolvedLang)) continue;
+      if (!isExecutable(resolvedLang) || isStaticBlock(options, this.settings.staticBlocksByDefault)) continue;
       // Dedent like the markdown renderer so the hash matches the rendered code.
       const code = contentLines.map((l) => stripFenceIndent(l, indent)).join("\n");
       entries.push({
@@ -2995,7 +2999,7 @@ __ocode_emit_vars
   // ─── Code Block Processing ────────────────────────────────────
 
   private processCodeBlocks(el: HTMLElement, ctx: MarkdownPostProcessorContext) {
-    const codeBlocks = el.querySelectorAll("pre > code");
+    const codeBlocks = el.querySelectorAll<HTMLElement>("pre > code");
     if (!codeBlocks.length) return;
 
     // Seed any `code_vars:` frontmatter variables into the note's var stores
@@ -3004,37 +3008,8 @@ __ocode_emit_vars
     // *after* this in renderVarsBlock and therefore override frontmatter vars.
     this.applyFrontmatterVars(ctx);
 
-    // Extract OPENING fence info strings from the raw section source so we can
-    // read space-separated attributes next to the language, e.g.
-    //     ```python skip collapsed
-    // Important: a code fence is a *pair* of fence lines. We must skip the
-    // closing fence; otherwise `fenceInfoStrings[bi]` becomes off-by-one as
-    // soon as the section contains more than one code block.
-    const fenceInfoStrings: string[] = [];
     const passthroughLanguages = this.passthroughLanguages();
-    const sectionInfo = ctx.getSectionInfo(el);
-    if (sectionInfo) {
-      // sectionInfo.text is the WHOLE file, not just this section — scanning
-      // it all would make every section's block inherit the attrs of the
-      // first fence in the note. Slice to this section's own lines.
-      const lines = sectionInfo.text
-        .split("\n")
-        .slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1);
-      let openFence: string | null = null;  // current open fence chars (``` or ~~~), or null when outside
-      for (const line of lines) {
-        const m = line.match(/^([`~]{3,})(.*)$/);
-        if (!m) continue;
-        const fenceChars = m[1][0].repeat(m[1].length);
-        if (openFence === null) {
-          // Opening fence
-          fenceInfoStrings.push(m[2].trim());
-          openFence = fenceChars;
-        } else if (line.startsWith(openFence) && m[2].trim() === "") {
-          // Closing fence (same char, length ≥ opener, no info text)
-          openFence = null;
-        }
-      }
-    }
+    const matchedFenceLines = new Set<number>();
 
     for (let bi = 0; bi < codeBlocks.length; bi++) {
       const codeEl = codeBlocks[bi];
@@ -3074,12 +3049,19 @@ __ocode_emit_vars
         continue;
       }
 
-      // Parse space-separated attributes from the fence info string, e.g.:
-      //   ```python skip collapsed   → attrs: { "skip", "collapsed" }
-      const infoStr = fenceInfoStrings[bi] ?? "";
-      const blockAttrs = new Set(
-        infoStr.split(/\s+/).slice(1).map((w) => w.toLowerCase()).filter(Boolean)
-      );
+      // Match source content within this element's section. Native renderers can
+      // remove earlier fences from the DOM, so a positional index is unreliable.
+      const section = ctx.getSectionInfo(pre) ?? ctx.getSectionInfo(codeEl) ?? ctx.getSectionInfo(el);
+      const renderedCode = (codeEl.textContent ?? "").replace(/\n$/, "");
+      const fence = section ? fencedBlockInfos(section.text.split("\n")
+        .slice(section.lineStart, section.lineEnd + 1).join("\n"))
+        .find((candidate) => !matchedFenceLines.has(section.lineStart + candidate.line)
+          && candidate.info.split(/\s+/)[0].toLowerCase() === rawLang.toLowerCase()
+          && candidate.code === renderedCode) : undefined;
+      if (fence && section) matchedFenceLines.add(section.lineStart + fence.line);
+      const infoStr = fence?.info ?? "";
+      const options = parseBlockOptions(infoStr);
+      const blockAttrs = options.flags;
       // Also pick up any extra classes Obsidian might add from the info string
       for (const cls of Array.from(codeEl.classList)) {
         if (!cls.startsWith("language-")) blockAttrs.add(cls.toLowerCase());
@@ -3087,10 +3069,7 @@ __ocode_emit_vars
       const forceSkip = blockAttrs.has("skip");
       // `collapsed` / `expanded` per-block overrides for the default state.
       // `null` means "use the global setting".
-      const forceCollapsed: boolean | null =
-        blockAttrs.has("collapsed") ? true
-        : blockAttrs.has("expanded") ? false
-        : null;
+      const forceCollapsed = options.collapsed ?? null;
 
       const lang = this.highlighter.resolveLanguage(rawLang);
       const code = codeEl.textContent || "";
@@ -3101,7 +3080,7 @@ __ocode_emit_vars
       if (htmlTemplate && htmlPreview === null) htmlPreview = true;
       const htmlPdf = this.htmlPdfState(rawLang, blockAttrs);
 
-      this.renderCodeBlock(pre, code, lang, rawLang, undefined, ctx.sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate);
+      this.renderCodeBlock(pre, code, lang, rawLang, undefined, ctx.sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options);
     }
   }
 
@@ -3888,9 +3867,10 @@ __ocode_emit_vars
     htmlPreview: boolean | null = null,
     htmlPdf = false,
     htmlTemplate = false,
+    options?: BlockOptions,
   ) {
     const wrapper = this.buildCodeBlockWrapper(
-      code, lang, displayLang, fileName, sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate,
+      code, lang, displayLang, fileName, sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options,
     );
     if (wrapper) originalPre.replaceWith(wrapper);
   }
@@ -3912,6 +3892,7 @@ __ocode_emit_vars
     htmlPreview: boolean | null = null,
     htmlPdf = false,
     htmlTemplate = false,
+    options?: BlockOptions,
   ): HTMLElement | null {
     // Strip a single trailing newline so Shiki doesn't emit a dangling empty
     // `.line` span — that's what made every block render one line too tall (#24).
@@ -3922,6 +3903,8 @@ __ocode_emit_vars
     const wrapper = createDiv();
     wrapper.className = "ocode-wrapper";
     wrapper.dataset.ocodeLang = lang;
+    const staticBlock = !fileName && (options?.static ?? this.settings.staticBlocksByDefault);
+    wrapper.toggleClass("ocode-static", staticBlock);
     const parsedHtml = new DOMParser().parseFromString(html, "text/html");
     for (const node of Array.from(parsedHtml.body.childNodes)) {
       wrapper.appendChild(activeDocument.adoptNode(node));
@@ -3931,10 +3914,10 @@ __ocode_emit_vars
     const header = createDiv();
     header.className = "ocode-header";
 
-    if (fileName || (this.settings.showLanguageLabel && displayLang)) {
+    if (options?.title || fileName || (this.settings.showLanguageLabel && displayLang)) {
       const label = createSpan();
-      label.className = "ocode-label";
-      label.textContent = fileName || displayLang;
+      label.className = options?.title ? "ocode-label ocode-block-title" : "ocode-label";
+      label.textContent = options?.title || fileName || displayLang;
       header.appendChild(label);
     }
 
@@ -3964,7 +3947,7 @@ __ocode_emit_vars
     });
     btnGroup.appendChild(copyBtn);
 
-    if (this.settings.enableExecution && isExecutable(lang) && Platform.isDesktop) {
+    if (!staticBlock && this.settings.enableExecution && isExecutable(lang) && Platform.isDesktop) {
       const runBtn = this.createPillButton("Run", ICON.play, () => {
         void this.runCode(code, lang, wrapper, runBtn, sourcePath);
       }, "ocode-run-pill");
@@ -3985,7 +3968,7 @@ __ocode_emit_vars
     wrapper.prepend(header);
 
     // ─── Line numbers ───
-    if (this.settings.showLineNumbers) {
+    if (options?.showLineNumbers ?? this.settings.showLineNumbers) {
       const shikiPre = wrapper.querySelector("pre");
       if (shikiPre) {
         const lines = shikiPre.querySelectorAll(".line");
@@ -4002,6 +3985,13 @@ __ocode_emit_vars
         if (lines.length) wrapper.addClass("ocode-has-lnum");
       }
     }
+
+    const lineOptions = options ?? parseBlockOptions("");
+    const sourceLines = displayCode.split("\n");
+    wrapper.querySelectorAll("pre .line").forEach((line, index) => {
+      const cls = lineHighlightClass(lineOptions, index + 1, sourceLines[index] ?? "", lang);
+      if (cls) line.classList.add(cls);
+    });
 
     // ─── Collapsible (reading view + Live Preview) ───
     // Every fenced code block is collapsible via its header — Python, html,
@@ -4020,21 +4010,21 @@ __ocode_emit_vars
     // non-runnable code blocks are excluded because parseSkipStatesFromSource()
     // does not count them. The code hash lets Run All match a source-parsed
     // block to its rendered wrapper even when duplicates exist (#25).
-    if (!fileName && isExecutable(lang)) {
+    if (!fileName && !staticBlock && isExecutable(lang)) {
       wrapper.setAttribute("data-ocode-fenced", "1");
       wrapper.setAttribute("data-ocode-hash", codeHash(code.trim()));
     }
 
     // Re-attach a previously-run output (this session) so it survives reading-
     // view section eviction and is present for HTML/PDF export.
-    if (!fileName && isExecutable(lang) && sourcePath) {
+    if (!fileName && !staticBlock && isExecutable(lang) && sourcePath) {
       this.restoreBlockOutput(sourcePath, code, wrapper);
     }
 
     // ─── HTML live preview ───
     // Render the block's HTML alongside its source and add a Preview/Code
     // toggle. `htmlPreview` is non-null only for preview-eligible html blocks.
-    if (htmlPreview !== null) {
+    if (!staticBlock && htmlPreview !== null) {
       this.addHtmlPreview(wrapper, code, htmlPreview, htmlPdf, sourcePath, htmlTemplate);
     }
     return wrapper;

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -316,13 +316,13 @@ export class CodeSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Line numbers")
-      .setDesc("Show line numbers in code blocks (reading view only).")
+      .setDesc("Show line numbers in code blocks. Per-block line-number fence options override this default.")
       .addToggle((t) => {
         t.setValue(this.plugin.settings.showLineNumbers);
         t.onChange(async (v) => {
           this.plugin.settings.showLineNumbers = v;
-          activeDocument.body.toggleClass("ocode-lp-lnum", v);
           await this.plugin.saveSettings();
+          this.plugin.refreshRenderedBlocks();
         });
       });
 
@@ -360,12 +360,42 @@ export class CodeSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Collapse code blocks by default")
-      .setDesc("Start every code block collapsed in reading view and live preview. Code blocks are always collapsible — click the header to expand/collapse; this only sets the initial state. Per-block 'collapsed'/'expanded' fence flags override it.")
+      .setDesc("Start every code block collapsed in reading view and live preview. Click the header to expand or collapse it. Per-block collapse/collapsed/expanded flags and fold=true/fold=false aliases override this default.")
       .addToggle((t) => {
         t.setValue(this.plugin.settings.inlineCollapsedByDefault);
         t.onChange(async (v) => {
           this.plugin.settings.inlineCollapsedByDefault = v;
           await this.plugin.saveSettings();
+          this.plugin.refreshRenderedBlocks();
+        });
+      });
+
+    // ─── Inline code ─────────────────────────────
+    new Setting(containerEl).setName("Inline code").setHeading();
+
+    new Setting(containerEl)
+      .setName("Enhanced inline code styling")
+      .setDesc("Give ordinary Markdown inline code a stronger background, border, and spacing so it stands out in prose.")
+      .addToggle((t) => {
+        t.setValue(this.plugin.settings.styleInlineCode);
+        t.onChange(async (v) => {
+          this.plugin.settings.styleInlineCode = v;
+          await this.plugin.saveSettings();
+          this.app.workspace.updateOptions();
+          this.plugin.refreshRenderedBlocks();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName("Inline syntax highlighting")
+      .setDesc("Highlight inline code that starts with a language prefix, for example `{python} result = values.sum()`.")
+      .addToggle((t) => {
+        t.setValue(this.plugin.settings.highlightInlineCode);
+        t.onChange(async (v) => {
+          this.plugin.settings.highlightInlineCode = v;
+          await this.plugin.saveSettings();
+          this.app.workspace.updateOptions();
+          this.plugin.refreshRenderedBlocks();
         });
       });
 
@@ -455,6 +485,18 @@ export class CodeSettingTab extends PluginSettingTab {
       .addToggle((t) => {
         t.setValue(this.plugin.settings.enableExecution);
         t.onChange(async (v) => { this.plugin.settings.enableExecution = v; await this.plugin.saveSettings(); });
+      });
+
+    new Setting(containerEl)
+      .setName("Static blocks by default")
+      .setDesc("Keep fenced code blocks highlighted but non-executable by default. Add static=false to a fence to make an individual block executable.")
+      .addToggle((t) => {
+        t.setValue(this.plugin.settings.staticBlocksByDefault);
+        t.onChange(async (v) => {
+          this.plugin.settings.staticBlocksByDefault = v;
+          await this.plugin.saveSettings();
+          this.plugin.refreshRenderedBlocks();
+        });
       });
 
     new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -114,6 +114,10 @@ export interface CodePluginSettings {
   demoThemeCycle?: boolean;
   /** Custom code font size in pixels. Null follows Obsidian's --code-size. */
   codeFontSize: number | null;
+  /** Give ordinary Markdown inline code CodeSuite's stronger visual treatment. */
+  styleInlineCode: boolean;
+  /** Apply Shiki token colors to inline code prefixed with `{lang}`. */
+  highlightInlineCode: boolean;
   showLineNumbers: boolean;
   showLanguageLabel: boolean;
   /**
@@ -124,6 +128,8 @@ export interface CodePluginSettings {
   /** Soft-wrap long lines in reading view instead of showing a horizontal scrollbar. */
   wrapCodeInReadingView: boolean;
   enableExecution: boolean;
+  /** Treat blocks as highlighted, non-executable code unless `static=false` overrides it. */
+  staticBlocksByDefault: boolean;
   renderEmbeddedFiles: boolean;
   /**
    * When true, `html` code blocks render as a live HTML preview by default
@@ -291,11 +297,14 @@ export const DEFAULT_SETTINGS: CodePluginSettings = {
   darkAutoTheme: "gruvbox-dark-hard",
   lightAutoTheme: "github-light",
   codeFontSize: null,
+  styleInlineCode: true,
+  highlightInlineCode: true,
   showLineNumbers: true,
   showLanguageLabel: true,
   additionalPassthroughLanguages: "base\nd2\nvid",
   wrapCodeInReadingView: true,
   enableExecution: true,
+  staticBlocksByDefault: false,
   renderEmbeddedFiles: true,
   renderHtmlBlocks: false,
   htmlBlockPdfExport: false,

--- a/styles.css
+++ b/styles.css
@@ -802,18 +802,16 @@ body.ocode-wide-blocks .ocode-wrapper {
    gutter-less "native" block before our chrome returns. Mirror the gutter here
    using document-derived attributes so folds and CM virtualization preserve the
    real code line number.
-   Gated by `body.ocode-lp-lnum`, which tracks the Line numbers setting.
+   The numbered-line class reflects the global setting and per-block overrides.
    Fence lines (begin/end) are not numbered — they have no number in chrome. */
-body.ocode-lp-lnum
-  .cm-s-obsidian
-  .cm-line.HyperMD-codeblock:not(.HyperMD-codeblock-begin):not(.HyperMD-codeblock-end) {
+.cm-s-obsidian
+  .cm-line.ocode-numbered-line.HyperMD-codeblock:not(.HyperMD-codeblock-begin):not(.HyperMD-codeblock-end) {
   position: relative;
   padding-left: calc(3em + 28px);
 }
 
-body.ocode-lp-lnum
-  .cm-s-obsidian
-  .cm-line.HyperMD-codeblock:not(.HyperMD-codeblock-begin):not(.HyperMD-codeblock-end)::before {
+.cm-s-obsidian
+  .cm-line.ocode-numbered-line.HyperMD-codeblock:not(.HyperMD-codeblock-begin):not(.HyperMD-codeblock-end)::before {
   content: attr(data-ocode-line-number);
   position: absolute;
   left: 4px;
@@ -1218,4 +1216,52 @@ body {
 /* Highlighting failed for this block — hide the empty fallback box. */
 .cm-content .ocode-lp-empty {
   display: none;
+}
+
+/* ─── Inline code ─────────────────────────────── */
+/* Added only to spans selected by the inline-code setting. The language prefix
+   is removed in reading view; Shiki token colors are applied inline. */
+.markdown-rendered code.ocode-inline-code,
+.cm-s-obsidian .ocode-inline-code {
+  background-color: var(--ocode-bg, var(--background-secondary));
+  color: var(--ocode-fg, var(--text-normal));
+  border: 1px solid color-mix(in srgb, var(--ocode-fg, var(--text-normal)) 18%, transparent);
+  border-radius: 4px;
+  padding: 0.12em 0.38em;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  font-size: 0.92em;
+}
+
+.markdown-rendered code.ocode-inline-code-highlighted {
+  white-space: break-spaces;
+}
+
+/* Per-block line emphasis, shared by rendered blocks and editable source. */
+.ocode-wrapper pre .line.ocode-line-highlight,
+.cm-s-obsidian .cm-line.ocode-line-highlight {
+  background-color: color-mix(in srgb, var(--text-accent) 16%, transparent);
+}
+.ocode-wrapper pre .line.ocode-line-insert,
+.cm-s-obsidian .cm-line.ocode-line-insert {
+  background-color: color-mix(in srgb, var(--color-green) 18%, transparent);
+}
+.ocode-wrapper pre .line.ocode-line-delete,
+.cm-s-obsidian .cm-line.ocode-line-delete {
+  background-color: color-mix(in srgb, var(--color-red) 18%, transparent);
+}
+
+.ocode-block-title {
+  text-transform: none;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+/* Native token spans sit inside our editor mark; only the outer mark adds spacing. */
+.cm-s-obsidian .ocode-inline-code .cm-inline-code {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font-size: inherit;
 }

--- a/tests/block-options.test.ts
+++ b/tests/block-options.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fencedBlockInfos, isStaticBlock, lineHighlightClass, parseBlockOptions } from "../src/block-options";
+
+test("preserves legacy bare flags and parses quoted titles without treating their words as options", () => {
+  const options = parseBlockOptions('python RUN NoPDF static=false title="A \\"quoted\\" static example"');
+  assert.deepEqual([...options.flags], ["run", "nopdf"]);
+  assert.equal(options.title, 'A "quoted" static example');
+  assert.equal(options.static, false);
+  assert.equal(parseBlockOptions("js title='Single quoted title'").title, "Single quoted title");
+});
+
+test("static overrides the default only when explicitly specified", () => {
+  assert.equal(isStaticBlock(parseBlockOptions("python")), false);
+  assert.equal(isStaticBlock(parseBlockOptions("python"), true), true);
+  assert.equal(isStaticBlock(parseBlockOptions("python static")), true);
+  assert.equal(isStaticBlock(parseBlockOptions("python static=true")), true);
+  assert.equal(isStaticBlock(parseBlockOptions("python static=false"), true), false);
+  assert.equal(parseBlockOptions("python static=maybe").static, undefined);
+});
+
+test("line-number and folding aliases support explicit booleans and last attribute wins", () => {
+  for (const alias of ["showLineNumbers", "ln=true", "ln:true", "hideLineNumbers=false"]) {
+    assert.equal(parseBlockOptions(`ts ${alias}`).showLineNumbers, true, alias);
+  }
+  for (const alias of ["hideLineNumbers", "ln=false", "ln:false", "showLineNumbers=false"]) {
+    assert.equal(parseBlockOptions(`ts ${alias}`).showLineNumbers, false, alias);
+  }
+  for (const alias of ["collapse", "collapsed", "fold=true", "fold:true", "expanded=false"]) {
+    assert.equal(parseBlockOptions(`ts ${alias}`).collapsed, true, alias);
+  }
+  for (const alias of ["expanded", "collapse=false", "collapsed=false", "fold=false", "fold:false"]) {
+    assert.equal(parseBlockOptions(`ts ${alias}`).collapsed, false, alias);
+  }
+  const options = parseBlockOptions("ts collapse expanded ln:true hideLineNumbers");
+  assert.equal(options.collapsed, false);
+  assert.equal(options.showLineNumbers, false);
+});
+
+test("line ranges retain bounded pairs, tolerate spaces, and ignore malformed entries", () => {
+  const options = parseBlockOptions("js {1, 5-10, 0, 7-2, nope, 2.5} ins={3, 12 - 14} del={4-9007199254740991, 9007199254740992}");
+  assert.deepEqual(options.highlight, [[1, 1], [5, 10]]);
+  assert.deepEqual(options.insert, [[3, 3], [12, 14]]);
+  assert.deepEqual(options.delete, [[4, Number.MAX_SAFE_INTEGER]]);
+});
+
+test("explicit deletion, insertion, and highlight ranges take precedence in that order", () => {
+  const options = parseBlockOptions("diff {1-4} ins={2-3} del={3}");
+  assert.equal(lineHighlightClass(options, 1, "+ explicit highlight", "diff"), "ocode-line-highlight");
+  assert.equal(lineHighlightClass(options, 2, "unchanged", "diff"), "ocode-line-insert");
+  assert.equal(lineHighlightClass(options, 3, "unchanged", "diff"), "ocode-line-delete");
+  assert.equal(lineHighlightClass(options, 5, "unchanged", "diff"), "");
+});
+
+test("diff additions and deletions are highlighted without marking file headers or other languages", () => {
+  const options = parseBlockOptions("diff");
+  assert.equal(lineHighlightClass(options, 1, "+added", "diff"), "ocode-line-insert");
+  assert.equal(lineHighlightClass(options, 2, "-removed", "diff"), "ocode-line-delete");
+  assert.equal(lineHighlightClass(options, 2, "+++counter", "diff"), "ocode-line-insert");
+  assert.equal(lineHighlightClass(options, 2, "---counter", "diff"), "ocode-line-delete");
+  for (const text of ["+++ b/file", "--- a/file", " context", "@@ -1 +1 @@"]) {
+    assert.equal(lineHighlightClass(options, 3, text, "diff"), "");
+  }
+  assert.equal(lineHighlightClass(options, 1, "+value", "python"), "");
+});
+
+test("reading metadata retains source positions and content for nested container fences", () => {
+  const source = [
+    "    indented code",
+    "",
+    "```mermaid",
+    "graph TD",
+    "```",
+    "> > ```python static",
+    "> > print(1)",
+    "> > ```",
+    "- ~~~js title='List example'",
+    "  const value = 1;",
+    "  ~~~",
+  ].join("\n");
+  assert.deepEqual(fencedBlockInfos(source), [
+    { info: "mermaid", code: "graph TD", line: 2 },
+    { info: "python static", code: "print(1)", line: 5 },
+    { info: "js title='List example'", code: "const value = 1;", line: 8 },
+  ]);
+});
+
+test("reading metadata does not confuse shorter inner fences with the closing fence", () => {
+  assert.deepEqual(fencedBlockInfos("````md title=example\n```python static\nprint(1)\n```\n````"), [
+    { info: "md title=example", code: "```python static\nprint(1)\n```", line: 0 },
+  ]);
+});
+
+
+test("backtick inline spans do not swallow later block metadata", () => {
+  assert.deepEqual(fencedBlockInfos("```inline```\n\n```python static\nprint(1)\n```"), [
+    { info: "python static", code: "print(1)", line: 2 },
+  ]);
+});

--- a/tests/inline-code.test.ts
+++ b/tests/inline-code.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseLanguageInlineCode, scanInlineCodeSpans } from "../src/inline-code";
+
+test("parses language-prefixed inline code", () => {
+  assert.deepEqual(parseLanguageInlineCode('{Python} result = df.groupby("region").sum()'), {
+    language: "python",
+    code: 'result = df.groupby("region").sum()',
+    codeOffset: 9,
+  });
+  assert.equal(parseLanguageInlineCode("ordinary code"), null);
+  assert.equal(parseLanguageInlineCode("{not a language} value"), null);
+});
+
+test("scans inline code delimiters without crossing lines", () => {
+  const source = "Before `{js} const answer = 42` and ``code with ` tick``.\nAfter `plain`.";
+  assert.deepEqual(scanInlineCodeSpans(source).map(({ text }) => text), [
+    "{js} const answer = 42",
+    "code with ` tick",
+    "plain",
+  ]);
+});
+
+test("ignores escaped delimiters and treats backslashes inside spans literally", () => {
+  assert.deepEqual(scanInlineCodeSpans("\\`not code\\`").map(({ text }) => text), []);
+  assert.deepEqual(scanInlineCodeSpans("`foo\\`").map(({ text }) => text), ["foo\\"]);
+});
+
+test("ignores top-level and nested fenced blocks", () => {
+  const source = [
+    "`before`",
+    "```js",
+    "`inside`",
+    "```",
+    "> - ```python",
+    ">   `nested`",
+    ">   ```",
+    "`after`",
+  ].join("\n");
+  assert.deepEqual(scanInlineCodeSpans(source).map(({ text }) => text), ["before", "after"]);
+});
+
+test("recognizes a same-line triple-backtick code span", () => {
+  assert.deepEqual(scanInlineCodeSpans("Use ```code with `` ticks``` here.").map(({ text }) => text), [
+    "code with `` ticks",
+  ]);
+});
+
+test("does not join unmatched spans across paragraphs or fences", () => {
+  const source = "`unclosed\n\n```js\n`inside`\n```\n\nend`";
+  assert.deepEqual(scanInlineCodeSpans(source), []);
+});


### PR DESCRIPTION
Closes #13.

Code blocks now support `static`, quoted titles, per-block line numbers, highlighted/inserted/deleted line ranges, and collapse overrides, including `ln=` and `fold=` aliases. Reading View and Live Preview share the formatting; editable source receives line numbers and backgrounds. Static blocks retain syntax colors while removing execution controls and Run All participation. A global static default can be overridden with `static=false`.

Ordinary inline code has configurable stronger styling, and `{lang}` prefixes enable Shiki colors. Diff blocks automatically emphasize additions and deletions. Added documentation and `examples/formatting.md` for manual verification.

Validation: TypeScript, ESLint, and automated tests. Obsidian visual verification has not been performed. Optional local Matplotlib and Plotly integration tests are skipped when their packages are unavailable.
