### PR TITLE
Fix block rendering ownership and local preview updates

### DIFF
--- a/scripts/test-rendering.cjs
+++ b/scripts/test-rendering.cjs
@@ -1,0 +1,120 @@
+// Run against an open, disposable vault containing the candidate plugin:
+// node scripts/test-rendering.cjs code-suite-render-lifecycle-clean
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const vault = process.argv[2];
+assert(vault?.startsWith('code-suite-render-'), 'Pass a disposable code-suite-render-* vault name');
+
+async function checkRendering() {
+  if (!app.vault.getName().startsWith('code-suite-render-')) throw Error('Not a rendering test vault');
+  const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
+  const check = (condition, message) => { if (!condition) throw Error(message); };
+  const results = [];
+  const leaves = app.workspace.getLeavesOfType('markdown').slice(0, 2);
+  while (leaves.length < 2) leaves.push(app.workspace.getLeaf('split'));
+  const open = async (path, source, modes) => {
+    let file = app.vault.getAbstractFileByPath(path);
+    if (file) await app.vault.modify(file, source);
+    else file = await app.vault.create(path, source);
+    for (const [index, leaf] of leaves.entries()) {
+      await leaf.openFile(file);
+      await leaf.setViewState({ type: 'markdown', state: { file: path, mode: modes[index], source: false } });
+      if (modes[index] === 'source') leaf.view.editor.setCursor({ line: 0, ch: 0 });
+    }
+    app.workspace.setActiveLeaf(leaves[0], { focus: true });
+    await pause(500);
+  };
+
+  const paragraphs = (label, count) => Array.from({ length: count }, (_, i) => `${label} ${i}. Some text.\n`).join('\n');
+  await open('Rendering scroll.md', paragraphs('Before', 45) + '\n```python\nprint(1)\n```\n\n' + paragraphs('After', 80), ['source', 'preview']);
+  const editor = leaves[0].view.editor, preview = leaves[1].view;
+  editor.setCursor({ line: 91, ch: 5 });
+  editor.scrollIntoView({ from: { line: 90, ch: 0 }, to: { line: 93, ch: 0 } }, true);
+  preview.previewMode.applyScroll(85);
+  await pause(400);
+  const scroll = preview.previewMode.getScroll(), editorScroll = editor.getScrollInfo().top;
+  editor.replaceRange(' static', { line: 90, ch: 9 });
+  await pause(600);
+  const wrapper = () => preview.contentEl.querySelector('.markdown-preview-view .ocode-wrapper');
+  check(Math.abs(preview.previewMode.getScroll() - scroll) < 1, 'Reading view jumped on a fence edit');
+  check(Math.abs(editor.getScrollInfo().top - editorScroll) < 2, 'Editing pane jumped');
+  check(wrapper()?.classList.contains('ocode-static'), 'Static option stayed stale');
+  check(!wrapper().querySelector('.ocode-run-pill'), 'Static block retained Run');
+  editor.replaceRange(' title="Updated" ln=false', { line: 90, ch: editor.getLine(90).length });
+  await pause(600);
+  check(wrapper().querySelector('.ocode-label')?.textContent === 'Updated', 'Title stayed stale');
+  check(!wrapper().querySelector('.ocode-line-num'), 'Line number option stayed stale');
+  editor.replaceRange('', { line: 90, ch: 9 }, { line: 90, ch: 16 });
+  await pause(600);
+  check(!!wrapper().querySelector('.ocode-run-pill'), 'Removing static did not restore Run');
+  editor.replaceRange('2', { line: 91, ch: 6 }, { line: 91, ch: 7 });
+  await pause(600);
+  check(wrapper().querySelector('pre')?.textContent.includes('print(2)'), 'Native source rendering stopped updating');
+  check(Math.abs(preview.previewMode.getScroll() - scroll) < 1, 'Reading view jumped on a source edit');
+  results.push('Split-pane edits preserve scroll and refresh static/title/line numbers/source');
+
+  editor.replaceRange('```javascript\nconsole.log("started"); setTimeout(() => console.log("finished"), 1200);\n```', { line: 90, ch: 0 }, { line: 92, ch: 3 });
+  await pause(600);
+  wrapper().querySelector('.ocode-run-pill').click();
+  await pause(200);
+  const runningWrapper = wrapper();
+  editor.replaceRange(' title="After running"', { line: 90, ch: editor.getLine(90).length });
+  await pause(400);
+  check(wrapper() === runningWrapper, 'Formatting replaced a running block');
+  for (let attempt = 0; attempt < 30 && !wrapper().querySelector('.ocode-output')?.textContent.includes('finished'); attempt++) await pause(100);
+  await pause(200);
+  check(wrapper().querySelector('.ocode-output')?.textContent.includes('finished'), 'Formatting lost running output');
+  check(wrapper().querySelector('.ocode-label')?.textContent === 'After running', 'Deferred formatting did not settle after execution');
+  results.push('Formatting during execution preserves output and updates after completion');
+
+  const block = '```python\nprint(1)\n```\n\n';
+  await open('Rendering duplicates.md', '# Duplicates\n\n' + block + block + 'After both blocks.\n', ['source', 'source']);
+  const wrappers = leaf => [...leaf.view.contentEl.querySelectorAll('.cm-content .ocode-wrapper')];
+  check(leaves.every(leaf => wrappers(leaf).length === 2), 'Duplicate blocks or panes share DOM');
+  const second = wrappers(leaves[0])[1];
+  second.querySelector('.ocode-header').click();
+  const duplicateEditor = leaves[0].view.editor;
+  duplicateEditor.replaceRange(' static', { line: 2, ch: 9 });
+  duplicateEditor.setCursor({ line: 0, ch: 0 });
+  await pause(500);
+  check(wrappers(leaves[0])[1] === second && second.classList.contains('ocode-collapsed'), 'Editing first duplicate transferred second block state');
+  duplicateEditor.replaceRange(block, { line: 2, ch: 0 });
+  duplicateEditor.setCursor({ line: 0, ch: 0 });
+  await pause(500);
+  check(wrappers(leaves[0])[2] === second, 'Inserting another block lost existing identity');
+  duplicateEditor.replaceRange('', { line: 2, ch: 0 }, { line: 6, ch: 0 });
+  duplicateEditor.setCursor({ line: 0, ch: 0 });
+  await pause(500);
+  check(wrappers(leaves[0])[1] === second, 'Deleting another block lost existing identity');
+  results.push('Duplicate blocks retain separate DOM and collapse state through edits/insertion/deletion in split panes');
+
+  const large = '# Large block\n\nBefore\n\n```python collapsed\n' + Array.from({ length: 500 }, (_, i) => `print(${i})`).join('\n') + '\n```\n\n' + paragraphs('After', 100);
+  await open('Rendering collapse.md', large, ['source', 'preview']);
+  for (const [index, leaf] of leaves.entries()) {
+    const view = leaf.view;
+    if (index === 0) view.editor.scrollTo(0, 0);
+    else view.previewMode.applyScroll(0);
+    await pause(200);
+    const root = view.contentEl.querySelector(index === 0 ? '.cm-content' : '.markdown-preview-view');
+    const blockEl = root.querySelector('.ocode-wrapper');
+    for (let cycle = 0; cycle < 3; cycle++) {
+      blockEl.querySelector('.ocode-header').click();
+      await pause(150);
+      check(blockEl.getBoundingClientRect().height > 5000, 'Large block did not expand');
+      blockEl.querySelector('.ocode-header').click();
+      await pause(150);
+      const after = [...root.querySelectorAll(index === 0 ? '.cm-line' : '.el-p')].find(el => el.textContent.startsWith('After 0.'));
+      check(after && after.getBoundingClientRect().top < innerHeight, 'Content below collapsed block is not rendered in viewport');
+      if (index === 0) check(Math.abs(view.editor.cm.contentHeight - root.getBoundingClientRect().height) < 2, 'CodeMirror height map is stale');
+    }
+  }
+  results.push('500-line blocks expand/collapse repeatedly with following content visible and accurate editor height');
+  return results;
+}
+
+const response = JSON.parse(execFileSync('obsidian', [
+  `vault=${vault}`, 'dev:cdp', 'method=Runtime.evaluate',
+  `params=${JSON.stringify({ expression: `(${checkRendering.toString()})()`, awaitPromise: true, returnByValue: true })}`,
+], { encoding: 'utf8' }));
+assert(!response.exceptionDetails, response.exceptionDetails?.exception?.description ?? JSON.stringify(response));
+for (const result of response.result.value) console.log(`PASS ${result}`);

--- a/scripts/test-rendering.cjs
+++ b/scripts/test-rendering.cjs
@@ -101,14 +101,24 @@ async function checkRendering() {
       blockEl.querySelector('.ocode-header').click();
       await pause(150);
       check(blockEl.getBoundingClientRect().height > 5000, 'Large block did not expand');
+      if (index === 1 && cycle === 0) {
+        // Evict the following sections while the tall block is expanded. A
+        // collapse without scrolling can leave them mounted and hide this bug.
+        for (let pass = 0; pass < 2; pass++) {
+          root.scrollTop = 4000;
+          await pause(600);
+          root.scrollTop = 0;
+          await pause(600);
+        }
+      }
       blockEl.querySelector('.ocode-header').click();
       await pause(150);
-      const after = [...root.querySelectorAll(index === 0 ? '.cm-line' : '.el-p')].find(el => el.textContent.startsWith('After 0.'));
+      const after = [...root.querySelectorAll(index === 0 ? '.cm-line' : '.el-p')].find(el => el.textContent.startsWith('After 1.'));
       check(after && after.getBoundingClientRect().top < innerHeight, 'Content below collapsed block is not rendered in viewport');
       if (index === 0) check(Math.abs(view.editor.cm.contentHeight - root.getBoundingClientRect().height) < 2, 'CodeMirror height map is stale');
     }
   }
-  results.push('500-line blocks expand/collapse repeatedly with following content visible and accurate editor height');
+  results.push('500-line blocks expand/scroll/collapse with evicted following content restored and accurate editor height');
   return results;
 }
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -12,6 +12,8 @@ const testBundles = [
   join(testDir, "shared-context.test.cjs"),
   join(testDir, "inline-code.test.cjs"),
   join(testDir, "block-options.test.cjs"),
+  join(testDir, "code-block-widget.test.cjs"),
+  join(testDir, "reading-code-block.test.cjs"),
 ];
 let exitCode = 1;
 
@@ -24,6 +26,8 @@ try {
       "tests/shared-context.test.ts",
       "tests/inline-code.test.ts",
       "tests/block-options.test.ts",
+      "tests/code-block-widget.test.ts",
+      "tests/reading-code-block.test.ts",
     ],
     bundle: true,
     platform: "node",

--- a/src/block-options.ts
+++ b/src/block-options.ts
@@ -110,13 +110,6 @@ export function fencedBlockInfos(source: string): { info: string; code: string; 
   return blocks;
 }
 
-/** Fingerprint fence option lines without changing when only block code changes. */
-export function fencedBlockOptionsSignature(source: string): string {
-  return fencedBlockInfos(source)
-    .map(({ line, info }) => `${line}:${info}`)
-    .join("\0");
-}
-
 export function lineHighlightClass(
   options: BlockOptions,
   lineNumber: number,

--- a/src/code-block-widget.ts
+++ b/src/code-block-widget.ts
@@ -1,0 +1,61 @@
+import { EditorView, WidgetType } from "@codemirror/view";
+
+// CodeMirror can replace an equal WidgetType without calling toDOM again.
+// Mount cleanup therefore belongs to the DOM, not the transient widget object.
+const mountedWrappers = new WeakMap<HTMLElement, () => void>();
+
+/** CodeMirror block widget with editor-owned DOM and measured dynamic height. */
+export class CodeBlockWidget extends WidgetType {
+  constructor(
+    private readonly owner: object,
+    private readonly key: string,
+    private readonly resolve: () => HTMLElement | null,
+  ) {
+    super();
+  }
+
+  eq(other: CodeBlockWidget): boolean {
+    return other.owner === this.owner && other.key === this.key;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const wrapper = this.resolve() ?? createDiv({ cls: "ocode-wrapper ocode-lp-empty" });
+    mountedWrappers.get(wrapper)?.();
+
+    const observer = new ResizeObserver(() => {
+      if (wrapper.isConnected) view.requestMeasure();
+    });
+    observer.observe(wrapper);
+
+    const codeArea = wrapper.querySelector<HTMLElement>("pre.shiki");
+    const reveal = (event: MouseEvent) => {
+      // Preserve modified gestures; ordinary clicks reveal the editable source.
+      if (event.button !== 0 || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return;
+      const pos = view.posAtDOM(wrapper);
+      event.preventDefault();
+      view.dispatch({ selection: { anchor: pos } });
+      view.focus();
+    };
+    codeArea?.addEventListener("mousedown", reveal);
+    mountedWrappers.set(wrapper, () => {
+      observer.disconnect();
+      codeArea?.removeEventListener("mousedown", reveal);
+    });
+    return wrapper;
+  }
+
+  destroy(dom: HTMLElement): void {
+    mountedWrappers.get(dom)?.();
+    mountedWrappers.delete(dom);
+  }
+
+  /** Chrome handles its own events; code-body clicks explicitly reveal source. */
+  ignoreEvent(): boolean {
+    return true;
+  }
+
+  /** Let CodeMirror measure the mounted DOM height. */
+  get estimatedHeight(): number {
+    return -1;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,9 +18,9 @@ import {
   editorInfoField,
   editorLivePreviewField,
 } from "obsidian";
-import { ViewPlugin, Decoration, EditorView, WidgetType } from "@codemirror/view";
+import { ViewPlugin, Decoration, EditorView } from "@codemirror/view";
 import type { DecorationSet, ViewUpdate } from "@codemirror/view";
-import { RangeSetBuilder, StateField, StateEffect, Prec } from "@codemirror/state";
+import { RangeSetBuilder, StateField, StateEffect, Prec, MapMode } from "@codemirror/state";
 import type { Extension, Text, EditorState, Range } from "@codemirror/state";
 import { Highlighter, EXT_TO_LANG } from "./highlighter";
 import {
@@ -28,9 +28,10 @@ import {
   isStaticBlock,
   lineHighlightClass,
   fencedBlockInfos,
-  fencedBlockOptionsSignature,
   type BlockOptions,
 } from "./block-options";
+import { CodeBlockWidget } from "./code-block-widget";
+import { ReadingCodeBlock } from "./reading-code-block";
 import { processInlineCode, buildInlineCodeEditorExtension } from "./inline-code";
 import { CodeSettingTab } from "./settings-tab";
 import { startExecution, isExecutable, type RunningProcess, type OutputFigure } from "./executor";
@@ -356,69 +357,12 @@ function scanFencedBlocks(doc: Text): FencedBlock[] {
  */
 const lpRebuildEffect = StateEffect.define<null>();
 
-/**
- * CM6 block widget that renders a CodeSuite `ocode-wrapper` in Live Preview.
- * The wrapper DOM is owned by the plugin's per-block cache (via `resolve`), so
- * the *same* node — with its live output and running process — is reused across
- * cursor moves and reveal/re-render cycles. `eq()` compares the cache key, which
- * already folds in language, source, block attributes, and the settings sig, so
- * CM never recreates a widget whose content is unchanged.
- */
-class CodeBlockWidget extends WidgetType {
-  constructor(
-    private readonly key: string,
-    private readonly resolve: () => HTMLElement | null,
-  ) {
-    super();
-  }
-
-  eq(other: CodeBlockWidget): boolean {
-    return other.key === this.key;
-  }
-
-  toDOM(view: EditorView): HTMLElement {
-    const wrapper = this.resolve() ?? createDiv({ cls: "ocode-wrapper ocode-lp-empty" });
-    this.wireReveal(view, wrapper);
-    return wrapper;
-  }
-
-  /**
-   * The widget owns all of its own events. We dispatch reveal explicitly on a
-   * code-body click (below), and the chrome's buttons have their own handlers,
-   * so CM6 must never treat a click as an editor gesture — otherwise a tall
-   * block (one with output) maps clicks to a position *outside* its range and
-   * the block never reveals for editing.
-   */
-  ignoreEvent(): boolean {
-    return true;
-  }
-
-  /**
-   * Clicking the code body reveals the raw source for editing. We can't rely on
-   * CM6's click-to-coordinate mapping (a block widget is atomic — clicks land at
-   * its edges, and output makes that unreliable), so we move the selection into
-   * the block ourselves. The next render sees the cursor overlap and drops the
-   * widget, exposing the editable lines.
-   */
-  private wireReveal(view: EditorView, wrapper: HTMLElement): void {
-    if (wrapper.dataset.ocodeRevealWired === "1") return;
-    wrapper.dataset.ocodeRevealWired = "1";
-    const codeArea = wrapper.querySelector<HTMLElement>("pre.shiki");
-    if (!codeArea) return;
-    codeArea.addEventListener("mousedown", (e) => {
-      // Let users still select text inside the code body (drag / modifier).
-      if (e.button !== 0 || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return;
-      const pos = view.posAtDOM(wrapper);
-      e.preventDefault();
-      view.dispatch({ selection: { anchor: pos } });
-      view.focus();
-    });
-  }
-
-  /** Let CM6 measure the real DOM height rather than guessing. */
-  get estimatedHeight(): number {
-    return -1;
-  }
+interface LivePreviewCache {
+  notePath: string;
+  wrappers: Map<string, HTMLElement>;
+  liveKeys: Set<string>;
+  invalidated: boolean;
+  nextIdentity: number;
 }
 
 /** Parse an SVG string into a DOM element without using innerHTML */
@@ -447,14 +391,8 @@ export default class CodePlugin extends Plugin {
    * so rapid manual clicks execute in click order instead of racing (#25).
    */
   private noteRunQueue: Map<string, Promise<void>> = new Map();
-  /**
-   * Live Preview block-widget DOM cache. Maps note path → blockKey
-   * (`lang\0code`) → the rendered `ocode-wrapper`. CM6 recreates widgets on
-   * every cursor move; returning the *same* DOM node keeps a block's streaming
-   * output and running process alive across cursor movement and reveal/re-render.
-   * In-memory only; pruned on rebuild and cleared on unload / rename / session clear.
-   */
-  private lpWrapperCache: Map<string, Map<string, HTMLElement>> = new Map();
+  /** Each mounted editor owns its retained block DOM, including duplicate blocks. */
+  private lpWrapperCache = new Set<LivePreviewCache>();
   /**
    * Shared execution context. Maps note path → language → ordered list of
    * previously-executed code blocks. In-memory only; cleared on unload.
@@ -520,9 +458,7 @@ export default class CodePlugin extends Plugin {
    *  {@link scheduleFrontmatterPanelSync}). */
   private _fmPanelSyncTimer: number | null = null;
 
-  /** Notes whose reading-view code chrome is stale after a fence option edit. */
-  private dirtyReadingBlockNotes = new Set<string>();
-  private _readingBlockRefreshTimer: number | null = null;
+  private readingBlocks = new Set<ReadingCodeBlock>();
 
   /** Demo/recording only — curated themes the demo-cycle command steps through. */
   private static readonly DEMO_THEME_CYCLE = [
@@ -537,8 +473,8 @@ export default class CodePlugin extends Plugin {
   private _demoThemeIdx = 0;
   /** Debounce timer for auto-theme switching (css-change can fire many times per mode switch) */
   private _autoThemeTimer: number | null = null;
-  /** Debounce timer for queued skip-badge sync passes. */
-  private _skipSyncTimer: number | null = null;
+  /** Debounce timer for mounted Reading view block updates. */
+  private _readingSyncTimer: number | null = null;
   /** Documents whose CodeSuite font-size override must be cleared on unload. */
   private _codeFontDocuments = new Set<Document>();
   /** True when no persisted data existed at load — i.e. a genuinely fresh install. */
@@ -664,21 +600,20 @@ export default class CodePlugin extends Plugin {
       })
     );
 
-    // Sync skip badges whenever the file is saved to disk (covers reading-view
-    // tabs open alongside an editing tab, and reloads after external changes).
+    // Refresh reused Reading view chrome after saves and external changes.
     this.registerEvent(
       this.app.vault.on("modify", (file) => {
         if (!(file instanceof TFile)) return;
-        this.queueSkipBadgeSync(file.path);
+        this.queueReadingBlockSync();
       })
     );
 
-    // Sync skip badges while typing in live preview (debounced 400 ms so we
-    // don't run on every keystroke).
+    // The native preview handles source edits; fence-only formatting may reuse
+    // its HTML, so refresh mounted block options once that render has settled.
     this.registerEvent(
       this.app.workspace.on("editor-change", (_editor, info) => {
         if (!(info instanceof MarkdownView)) return;
-        this.queueSkipBadgeSync(info.file?.path, 400);
+        this.queueReadingBlockSync(150);
       })
     );
 
@@ -721,14 +656,12 @@ export default class CodePlugin extends Plugin {
       this.app.workspace.on("layout-change", () => {
         this.applyCodeFontSize();
         this.forceLpRebuild();
-        this.refreshDirtyReadingBlocks();
         this.scheduleFrontmatterPanelSync();
       })
     );
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", () => {
         this.forceLpRebuild();
-        this.refreshDirtyReadingBlocks();
         this.scheduleFrontmatterPanelSync();
       })
     );
@@ -742,6 +675,7 @@ export default class CodePlugin extends Plugin {
     this.registerEvent(
       this.app.metadataCache.on("changed", () => {
         this.forceLpRebuild();
+        this.queueReadingBlockSync();
         this.scheduleFrontmatterPanelSync();
       })
     );
@@ -891,15 +825,12 @@ export default class CodePlugin extends Plugin {
       window.clearTimeout(this._autoThemeTimer);
       this._autoThemeTimer = null;
     }
-    if (this._skipSyncTimer !== null) {
-      window.clearTimeout(this._skipSyncTimer);
-      this._skipSyncTimer = null;
+    if (this._readingSyncTimer !== null) {
+      window.clearTimeout(this._readingSyncTimer);
+      this._readingSyncTimer = null;
     }
-    if (this._readingBlockRefreshTimer !== null) {
-      window.clearTimeout(this._readingBlockRefreshTimer);
-      this._readingBlockRefreshTimer = null;
-    }
-    this.dirtyReadingBlockNotes.clear();
+    for (const block of this.readingBlocks) block.unload();
+    this.readingBlocks.clear();
     for (const leaf of this.app.workspace.getLeavesOfType("markdown")) {
       if (leaf.view instanceof MarkdownView) this.cancelRunAll(leaf.view);
     }
@@ -911,7 +842,7 @@ export default class CodePlugin extends Plugin {
     this.runNotePaths.clear();
     this.noteRunQueue.clear();
     this.matlabSessions.disposeAll();
-    this.lpWrapperCache.clear();
+    for (const cache of this.lpWrapperCache) this.disposeLpCache(cache);
     this.highlighter.dispose();
     activeDocument.body.removeClass("ocode-wide-blocks");
     activeDocument.body.removeClass("ocode-wrap-code");
@@ -989,7 +920,7 @@ export default class CodePlugin extends Plugin {
    * views — without the full highlighter teardown {@link refreshHighlighter} does.
    */
   refreshRenderedBlocks(): void {
-    this.lpWrapperCache.clear();
+    for (const cache of this.lpWrapperCache) this.disposeLpCache(cache);
     this.forceLpRebuild();
     this.app.workspace.iterateAllLeaves((leaf) => {
       const view = leaf.view;
@@ -1236,7 +1167,14 @@ export default class CodePlugin extends Plugin {
    * come from a StateField, not a ViewPlugin, so they can affect line layout.
    */
   private buildBlockWidgetExtension(): Extension {
-    const build = (state: EditorState): DecorationSet => {
+    const createCache = (state: EditorState): LivePreviewCache => ({
+      notePath: state.field(editorInfoField, false)?.file?.path ?? "",
+      wrappers: new Map(),
+      liveKeys: new Set(),
+      invalidated: false,
+      nextIdentity: 0,
+    });
+    const build = (state: EditorState, cache: LivePreviewCache, positions: Map<number, number>): DecorationSet => {
       // Only in Live Preview — raw Source mode must stay plain text.
       if (!state.field(editorLivePreviewField)) return Decoration.none;
       const info = state.field(editorInfoField, false);
@@ -1254,6 +1192,16 @@ export default class CodePlugin extends Plugin {
         sel.ranges.some((r) => r.from <= to && r.to >= from);
 
       const liveKeys = new Set<string>();
+      const livePositions = new Set<number>();
+      const uniqueKey = (position: number, signature: string): string => {
+        livePositions.add(position);
+        let identity = positions.get(position);
+        if (identity === undefined) {
+          identity = cache.nextIdentity++;
+          positions.set(position, identity);
+        }
+        return `${identity}\0${signature}`;
+      };
       const items: { from: number; to: number; deco: Decoration }[] = [];
       const passthroughLanguages = this.passthroughLanguages();
 
@@ -1272,16 +1220,16 @@ export default class CodePlugin extends Plugin {
           const output = parseBakedOutput(block.code);
           if (output) {
             const stale = prevCodeHash !== null && prevCodeHash !== output.hash;
-            const key = `baked\0${output.hash}\0${stale}\0${block.code}\0${sig}`;
+            const key = uniqueKey(block.openFrom, `baked\0${output.hash}\0${stale}\0${block.code}\0${sig}`);
             liveKeys.add(key);
             if (!overlapsSelection(block.openFrom, block.closeTo)) {
               const resolve = (): HTMLElement | null =>
-                this.getCachedLpWrapper(notePath, key, () =>
+                this.getCachedLpWrapper(cache, key, () =>
                   this.buildBakedOutputWrapper(output, notePath, stale));
               items.push({
                 from: block.openFrom,
                 to: block.closeTo,
-                deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(key, resolve) }),
+                deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(cache, key, resolve) }),
               });
             }
           }
@@ -1315,7 +1263,7 @@ export default class CodePlugin extends Plugin {
         const tmplSig = htmlTemplate ? this.frontmatterSig(notePath) : "";
         // Visual indent in editor columns, so the widget lines up with its list.
         const indentCols = this.indentColumns(block.indent, state.tabSize);
-        const key = `${block.info}\0${this.lpBlockKey(resolvedLang, code)}\0${forceSkip}\0${forceCollapsed}\0${htmlPreview}\0${htmlPdf}\0${htmlTemplate}\0${tmplSig}\0${indentCols}\0${sig}`;
+        const key = uniqueKey(block.openFrom, `${block.info}\0${this.lpBlockKey(resolvedLang, code)}\0${forceSkip}\0${forceCollapsed}\0${htmlPreview}\0${htmlPdf}\0${htmlTemplate}\0${tmplSig}\0${indentCols}\0${sig}`);
         // Register the key BEFORE the cursor check so a block being edited (or
         // running) is never pruned out from under its live output / process.
         liveKeys.add(key);
@@ -1324,7 +1272,7 @@ export default class CodePlugin extends Plugin {
         if (overlapsSelection(block.openFrom, block.closeTo)) continue;
 
         const resolve = (): HTMLElement | null =>
-          this.getCachedLpWrapper(notePath, key, () => {
+          this.getCachedLpWrapper(cache, key, () => {
             const w = isVars
               ? this.buildVarsWrapper(code, notePath)
               : this.buildCodeBlockWrapper(
@@ -1342,7 +1290,7 @@ export default class CodePlugin extends Plugin {
         items.push({
           from: block.openFrom,
           to: block.closeTo,
-          deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(key, resolve) }),
+          deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(cache, key, resolve) }),
         });
       }
 
@@ -1369,11 +1317,11 @@ export default class CodePlugin extends Plugin {
           // costs a harmless extra rebuild on a frontmatter edit.
           const maybeTemplate = this.embedMaybeTemplate(ext, alias);
           const tmplSig = maybeTemplate ? this.frontmatterSig(notePath) : "";
-          const key = `embed\0${file.path}\0${htmlPreview}\0${htmlPdf}\0${maybeTemplate}\0${tmplSig}\0${sig}`;
+          const key = uniqueKey(line.from, `embed\0${file.path}\0${htmlPreview}\0${htmlPdf}\0${maybeTemplate}\0${tmplSig}\0${sig}`);
           liveKeys.add(key);
           if (overlapsSelection(line.from, line.to)) continue;
           const resolve = (): HTMLElement | null =>
-            this.getCachedLpWrapper(notePath, key, () => {
+            this.getCachedLpWrapper(cache, key, () => {
               const container = createDiv({ cls: "ocode-embed-container" });
               void this.populateEmbedContainer(container, file, ext, notePath, alias);
               return container;
@@ -1381,12 +1329,15 @@ export default class CodePlugin extends Plugin {
           items.push({
             from: line.from,
             to: line.to,
-            deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(key, resolve) }),
+            deco: Decoration.replace({ block: true, widget: new CodeBlockWidget(cache, key, resolve) }),
           });
         }
       }
 
-      this.pruneLpWrapperCache(notePath, liveKeys);
+      cache.liveKeys = liveKeys;
+      for (const position of positions.keys()) {
+        if (!livePositions.has(position)) positions.delete(position);
+      }
 
       items.sort((a, b) => a.from - b.from);
       const builder = new RangeSetBuilder<Decoration>();
@@ -1394,17 +1345,20 @@ export default class CodePlugin extends Plugin {
       return builder.finish();
     };
 
-    const queueReadingRefreshFor = (state: EditorState): void => {
-      const notePath = state.field(editorInfoField, false)?.file?.path;
-      if (notePath) this.queueReadingBlockRefresh(notePath);
-    };
-
     // Highest precedence so our block-replace widgets win over Obsidian's own
     // Live Preview code-block rendering. Without this, the two compete over the
     // same fence lines and Obsidian's native render (language flag, no chrome)
     // intermittently shows through until a selection change re-asserts ours.
-    const field = StateField.define<DecorationSet>({
-      create: (state) => build(state),
+    const field = StateField.define<{
+      decorations: DecorationSet;
+      cache: LivePreviewCache;
+      positions: Map<number, number>;
+    }>({
+      create: (state) => {
+        const cache = createCache(state);
+        const positions = new Map<number, number>();
+        return { decorations: build(state, cache, positions), cache, positions };
+      },
       update(value, tr) {
         // Toggling Live Preview ↔ Source mode flips this field with no doc or
         // selection change — rebuild so chrome appears/disappears immediately
@@ -1412,26 +1366,48 @@ export default class CodePlugin extends Plugin {
         const lpChanged =
           tr.startState.field(editorLivePreviewField, false) !==
           tr.state.field(editorLivePreviewField, false);
+        const cacheChanged = value.cache.invalidated ||
+          value.cache.notePath !== (tr.state.field(editorInfoField, false)?.file?.path ?? "");
         if (
-          tr.docChanged &&
-          fencedBlockOptionsSignature(tr.startState.doc.toString()) !==
-            fencedBlockOptionsSignature(tr.state.doc.toString())
-        ) {
-          queueReadingRefreshFor(tr.state);
-        }
-        if (
+          cacheChanged ||
           lpChanged ||
           tr.docChanged ||
           tr.selection ||
           tr.effects.some((e) => e.is(lpRebuildEffect))
         ) {
-          return build(tr.state);
+          const cache = cacheChanged ? createCache(tr.state) : value.cache;
+          const positions = new Map<number, number>();
+          if (!cacheChanged) {
+            // Follow each opening fence through edits, keeping identical blocks
+            // distinct when another occurrence is inserted, edited, or removed.
+            for (const [position, identity] of value.positions) {
+              const mapped = tr.changes.mapPos(position, 1, MapMode.TrackAfter);
+              if (mapped !== null) positions.set(mapped, identity);
+            }
+          }
+          return { decorations: build(tr.state, cache, positions), cache, positions };
         }
-        return value.map(tr.changes);
+        return value;
       },
-      provide: (f) => EditorView.decorations.from(f),
+      provide: (f) => EditorView.decorations.from(f, (value) => value.decorations),
     });
-    return Prec.highest(field);
+    const lifecycle = ViewPlugin.define((view) => {
+      let cache = view.state.field(field).cache;
+      this.lpWrapperCache.add(cache);
+      return {
+        update: (update: ViewUpdate) => {
+          const next = update.state.field(field).cache;
+          if (next !== cache) {
+            this.disposeLpCache(cache);
+            cache = next;
+            this.lpWrapperCache.add(cache);
+          }
+          this.pruneLpWrapperCache(cache);
+        },
+        destroy: () => this.disposeLpCache(cache),
+      };
+    });
+    return [Prec.highest(field), lifecycle];
   }
 
   // ─── Shared Execution Context ────────────────────────────────
@@ -1523,46 +1499,37 @@ export default class CodePlugin extends Plugin {
    * `build()` on a miss. Reusing the same node keeps streaming output and the
    * running process alive across the cursor moving in/out of the block.
    */
-  private getCachedLpWrapper(notePath: string, key: string, build: () => HTMLElement | null): HTMLElement | null {
-    let perNote = this.lpWrapperCache.get(notePath);
-    const existing = perNote?.get(key);
+  private getCachedLpWrapper(cache: LivePreviewCache, key: string, build: () => HTMLElement | null): HTMLElement | null {
+    const existing = cache.wrappers.get(key);
     if (existing) return existing;
     const wrapper = build();
-    if (!wrapper) return null;
-    if (!perNote) { perNote = new Map(); this.lpWrapperCache.set(notePath, perNote); }
-    perNote.set(key, wrapper);
+    if (wrapper) cache.wrappers.set(key, wrapper);
     return wrapper;
   }
 
-  /**
-   * Evict cached wrappers for a note whose keys are no longer present in the
-   * document, so edited/removed blocks don't leak DOM (and their processes).
-   * `liveKeys` is the set of block keys currently in the doc.
-   */
-  private pruneLpWrapperCache(notePath: string, liveKeys: Set<string>): void {
-    const perNote = this.lpWrapperCache.get(notePath);
-    if (!perNote) return;
-    for (const [key, wrapper] of perNote) {
-      if (!liveKeys.has(key)) {
-        this.runningProcs.get(wrapper)?.cancel();
-        this.runningProcs.delete(wrapper);
-        this.runNotePaths.delete(wrapper);
-        perNote.delete(key);
-      }
-    }
-    if (perNote.size === 0) this.lpWrapperCache.delete(notePath);
-  }
-
-  /** Drop all cached wrappers for a note, cancelling any processes they own. */
-  private dropLpWrapperCache(notePath: string): void {
-    const perNote = this.lpWrapperCache.get(notePath);
-    if (!perNote) return;
-    for (const wrapper of perNote.values()) {
+  /** Prune after the editor commits its state, never while computing decorations. */
+  private pruneLpWrapperCache(cache: LivePreviewCache): void {
+    for (const [key, wrapper] of cache.wrappers) {
+      if (cache.liveKeys.has(key)) continue;
       this.runningProcs.get(wrapper)?.cancel();
       this.runningProcs.delete(wrapper);
       this.runNotePaths.delete(wrapper);
+      cache.wrappers.delete(key);
     }
-    this.lpWrapperCache.delete(notePath);
+  }
+
+  private disposeLpCache(cache: LivePreviewCache): void {
+    cache.liveKeys.clear();
+    this.pruneLpWrapperCache(cache);
+    cache.invalidated = true;
+    this.lpWrapperCache.delete(cache);
+  }
+
+  /** Invalidate every editor showing the note, retaining no DOM across owners. */
+  private dropLpWrapperCache(notePath: string): void {
+    for (const cache of this.lpWrapperCache) {
+      if (cache.notePath === notePath) this.disposeLpCache(cache);
+    }
   }
 
   /**
@@ -1695,105 +1662,13 @@ export default class CodePlugin extends Plugin {
     return entries;
   }
 
-  /** Queue a lightweight skip-badge DOM sync for already-rendered views. */
-  private queueSkipBadgeSync(notePath?: string, delay = 0): void {
-    if (this._skipSyncTimer !== null) {
-      window.clearTimeout(this._skipSyncTimer);
-    }
-    this._skipSyncTimer = window.setTimeout(() => {
-      this._skipSyncTimer = null;
-      const views: MarkdownView[] = [];
-      this.app.workspace.iterateAllLeaves((leaf) => {
-        const view = leaf.view;
-        if (!(view instanceof MarkdownView)) return;
-        if (notePath && view.file?.path !== notePath) return;
-        views.push(view);
-      });
-      if (views.length === 0) return;
-      for (const view of views) this.syncSkipBadges(view);
+  /** Coalesce edits across notes, then update only mounted Reading view blocks. */
+  private queueReadingBlockSync(delay = 0): void {
+    if (this._readingSyncTimer !== null) window.clearTimeout(this._readingSyncTimer);
+    this._readingSyncTimer = window.setTimeout(() => {
+      this._readingSyncTimer = null;
+      for (const block of this.readingBlocks) block.sync();
     }, delay);
-  }
-
-  /**
-   * Re-render a note's reading-view block chrome after an opening fence changes.
-   * Keep the note dirty when it is currently in Source mode, then flush as soon
-   * as the mode switch produces a reading view.
-   */
-  private queueReadingBlockRefresh(notePath: string): void {
-    this.dirtyReadingBlockNotes.add(notePath);
-    if (this._readingBlockRefreshTimer !== null) {
-      window.clearTimeout(this._readingBlockRefreshTimer);
-    }
-    this._readingBlockRefreshTimer = window.setTimeout(() => {
-      this._readingBlockRefreshTimer = null;
-      this.refreshDirtyReadingBlocks();
-    }, 150);
-  }
-
-  private refreshDirtyReadingBlocks(): void {
-    if (this._readingBlockRefreshTimer !== null) {
-      window.clearTimeout(this._readingBlockRefreshTimer);
-      this._readingBlockRefreshTimer = null;
-    }
-    const refreshed = new Set<string>();
-    this.app.workspace.iterateAllLeaves((leaf) => {
-      const view = leaf.view;
-      if (!(view instanceof MarkdownView)) return;
-      const notePath = view.file?.path;
-      if (!notePath || view.getMode() !== "preview" || !this.dirtyReadingBlockNotes.has(notePath)) return;
-      view.previewMode.rerender(true);
-      refreshed.add(notePath);
-    });
-    for (const notePath of refreshed) this.dirtyReadingBlockNotes.delete(notePath);
-  }
-
-  /**
-   * Sync the skip-badge and ocode-skip-run-all class for every inline fenced
-   * code block in the view against the current source state. Called on every
-    * file save and (debounced) on every editor change so already-rendered badges
-    * stay live without forcing a markdown preview rerender.
-   */
-  private syncSkipBadges(view: MarkdownView): void {
-    const source = view.getViewData();
-    if (!source) return;
-    // Match wrappers to source blocks by code hash, not by index — the reading
-    // view virtualizes sections, so off-screen blocks have no wrapper and any
-    // positional alignment shifts the skip states onto the wrong blocks (#25).
-    // Duplicate blocks share a hash; their states queue up in source order.
-    const statesByHash = new Map<string, boolean[]>();
-    for (const entry of this.parseRunAllPlan(source)) {
-      if (entry.kind !== "fence" || !entry.hash) continue;
-      let queue = statesByHash.get(entry.hash);
-      if (!queue) statesByHash.set(entry.hash, (queue = []));
-      queue.push(entry.skip);
-    }
-    // Scope to the reading view only. Live Preview widgets bake their skip
-    // badge in at build time, and the cursor's block has no widget.
-    const wrappers = Array.from(
-      view.contentEl.querySelectorAll<HTMLElement>('.markdown-reading-view .ocode-wrapper[data-ocode-fenced="1"]')
-    );
-    for (const wrapper of wrappers) {
-      const queue = statesByHash.get(wrapper.getAttribute("data-ocode-hash") ?? "");
-      // No source entry for this wrapper (stale render mid-edit) — leave it.
-      const shouldSkip = queue && queue.length > 0
-        ? queue.shift()!
-        : wrapper.classList.contains("ocode-skip-run-all");
-      const wasMarked = wrapper.classList.contains("ocode-skip-run-all");
-      if (shouldSkip === wasMarked) continue;
-      if (shouldSkip) {
-        wrapper.classList.add("ocode-skip-run-all");
-        const btnGroup = wrapper.querySelector(".ocode-btn-group");
-        if (btnGroup && !btnGroup.querySelector(".ocode-skip-badge")) {
-          const badge = createSpan({ cls: "ocode-skip-badge", text: "skip" });
-          badge.setAttribute("aria-label", "Excluded from run all");
-          badge.setAttribute("title", "Excluded from run all");
-          btnGroup.insertBefore(badge, btnGroup.firstChild);
-        }
-      } else {
-        wrapper.classList.remove("ocode-skip-run-all");
-        wrapper.querySelector(".ocode-skip-badge")?.remove();
-      }
-    }
   }
 
   /**
@@ -1818,7 +1693,7 @@ export default class CodePlugin extends Plugin {
       return;
     }
     // Sync badges first so the visual state is correct before we start running.
-    this.syncSkipBadges(view);
+    for (const block of this.readingBlocks) block.sync();
 
     // Register the pass so the header button can cancel it mid-run.
     const ctl = {
@@ -3126,9 +3001,9 @@ __ocode_emit_vars
       // remove earlier fences from the DOM, so a positional index is unreliable.
       const section = ctx.getSectionInfo(pre) ?? ctx.getSectionInfo(codeEl) ?? ctx.getSectionInfo(el);
       const renderedCode = (codeEl.textContent ?? "").replace(/\n$/, "");
-      const fence = section ? fencedBlockInfos(section.text.split("\n")
-        .slice(section.lineStart, section.lineEnd + 1).join("\n"))
-        .find((candidate) => !matchedFenceLines.has(section.lineStart + candidate.line)
+      const fences = section ? fencedBlockInfos(section.text.split("\n")
+        .slice(section.lineStart, section.lineEnd + 1).join("\n")) : [];
+      const fence = section ? fences.find((candidate) => !matchedFenceLines.has(section.lineStart + candidate.line)
           && candidate.info.split(/\s+/)[0].toLowerCase() === rawLang.toLowerCase()
           && candidate.code === renderedCode) : undefined;
       if (fence && section) matchedFenceLines.add(section.lineStart + fence.line);
@@ -3153,7 +3028,34 @@ __ocode_emit_vars
       if (htmlTemplate && htmlPreview === null) htmlPreview = true;
       const htmlPdf = this.htmlPdfState(rawLang, blockAttrs);
 
-      this.renderCodeBlock(pre, code, lang, rawLang, undefined, ctx.sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options);
+      const wrapper = this.buildCodeBlockWrapper(code, lang, rawLang, undefined, ctx.sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options);
+      if (!wrapper) continue;
+      pre.replaceWith(wrapper);
+      if (fence) {
+        let previousOptions = options;
+        ctx.addChild(new ReadingCodeBlock(wrapper, ctx, fences.indexOf(fence), fence, (info, current) => {
+          // A running process owns its output and controls until it finishes.
+          if (this.runningProcs.has(current)) return null;
+          const nextOptions = parseBlockOptions(info);
+          const attrs = nextOptions.flags;
+          const template = this.htmlTemplateState(rawLang, attrs, code);
+          let preview = this.htmlPreviewState(rawLang, attrs);
+          if (template && preview === null) preview = true;
+          const collapsed = nextOptions.collapsed === previousOptions.collapsed
+            ? current.classList.contains("ocode-collapsed")
+            : nextOptions.collapsed ?? this.settings.inlineCollapsedByDefault;
+          const next = this.buildCodeBlockWrapper(code, lang, rawLang, undefined, ctx.sourcePath,
+            attrs.has("skip"), collapsed, preview, this.htmlPdfState(rawLang, attrs), template, nextOptions);
+          if (!next) return null;
+          const output = current.querySelector(":scope > .ocode-output");
+          if (output) {
+            next.querySelector(":scope > .ocode-output")?.remove();
+            next.appendChild(output);
+          }
+          previousOptions = nextOptions;
+          return next;
+        }, this.readingBlocks));
+      }
     }
   }
 
@@ -3928,30 +3830,10 @@ __ocode_emit_vars
     return this.settings.htmlTemplating;
   }
 
-  private renderCodeBlock(
-    originalPre: HTMLElement,
-    code: string,
-    lang: string,
-    displayLang: string,
-    fileName?: string,
-    sourcePath?: string,
-    forceSkip = false,
-    forceCollapsed: boolean | null = null,
-    htmlPreview: boolean | null = null,
-    htmlPdf = false,
-    htmlTemplate = false,
-    options?: BlockOptions,
-  ) {
-    const wrapper = this.buildCodeBlockWrapper(
-      code, lang, displayLang, fileName, sourcePath, forceSkip, forceCollapsed, htmlPreview, htmlPdf, htmlTemplate, options,
-    );
-    if (wrapper) originalPre.replaceWith(wrapper);
-  }
-
   /**
    * Build the `ocode-wrapper` chrome (header, Shiki body, line numbers, collapse)
-   * for a code block and return it. Shared by the reading-view post-processor
-   * ({@link renderCodeBlock}) and the Live Preview block widget so both views
+   * for a code block and return it. Shared by the Reading view post-processor
+   * and the Live Preview block widget so both views
    * render identical chrome. Returns `null` only when highlighting fails.
    */
   private buildCodeBlockWrapper(
@@ -5124,6 +5006,7 @@ __ocode_emit_vars
         setSvgContent(runBtn.querySelector(".ocode-pill-icon")!, ICON.play);
         runBtn.querySelector(".ocode-pill-text")!.textContent = "Run";
         runBtn.classList.remove("ocode-cancel-pill");
+        this.queueReadingBlockSync();
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -459,6 +459,8 @@ export default class CodePlugin extends Plugin {
   private _fmPanelSyncTimer: number | null = null;
 
   private readingBlocks = new Set<ReadingCodeBlock>();
+  private readingLayoutChanges = new Set<HTMLElement>();
+  private readingLayoutFrame: number | null = null;
 
   /** Demo/recording only — curated themes the demo-cycle command steps through. */
   private static readonly DEMO_THEME_CYCLE = [
@@ -831,6 +833,9 @@ export default class CodePlugin extends Plugin {
     }
     for (const block of this.readingBlocks) block.unload();
     this.readingBlocks.clear();
+    if (this.readingLayoutFrame !== null) window.cancelAnimationFrame(this.readingLayoutFrame);
+    this.readingLayoutFrame = null;
+    this.readingLayoutChanges.clear();
     for (const leaf of this.app.workspace.getLeavesOfType("markdown")) {
       if (leaf.view instanceof MarkdownView) this.cancelRunAll(leaf.view);
     }
@@ -1660,6 +1665,22 @@ export default class CodePlugin extends Plugin {
       });
     }
     return entries;
+  }
+
+  /** Remeasure affected panes without rebuilding their Markdown or moving scroll. */
+  private queueReadingLayout(wrapper: HTMLElement): void {
+    this.readingLayoutChanges.add(wrapper);
+    if (this.readingLayoutFrame !== null) return;
+    this.readingLayoutFrame = window.requestAnimationFrame(() => {
+      this.readingLayoutFrame = null;
+      const changed = [...this.readingLayoutChanges];
+      this.readingLayoutChanges.clear();
+      this.app.workspace.iterateAllLeaves((leaf) => {
+        const view = leaf.view;
+        if (view instanceof MarkdownView && view.getMode() === "preview" &&
+          changed.some((element) => view.contentEl.contains(element))) view.onResize();
+      });
+    });
   }
 
   /** Coalesce edits across notes, then update only mounted Reading view blocks. */
@@ -3054,7 +3075,7 @@ __ocode_emit_vars
           }
           previousOptions = nextOptions;
           return next;
-        }, this.readingBlocks));
+        }, this.readingBlocks, (element) => this.queueReadingLayout(element)));
       }
     }
   }

--- a/src/reading-code-block.ts
+++ b/src/reading-code-block.ts
@@ -3,6 +3,8 @@ import { fencedBlockInfos } from "./block-options";
 
 /** Refresh only reused fence chrome; Obsidian owns source rendering and scrolling. */
 export class ReadingCodeBlock extends MarkdownRenderChild {
+  private observer: ResizeObserver | null = null;
+
   constructor(
     wrapper: HTMLElement,
     private readonly ctx: MarkdownPostProcessorContext,
@@ -10,6 +12,7 @@ export class ReadingCodeBlock extends MarkdownRenderChild {
     private fence: ReturnType<typeof fencedBlockInfos>[number],
     private readonly render: (info: string, current: HTMLElement) => HTMLElement | null,
     private readonly mounted: Set<ReadingCodeBlock>,
+    private readonly resized: (wrapper: HTMLElement) => void,
   ) {
     super(wrapper);
   }
@@ -17,6 +20,22 @@ export class ReadingCodeBlock extends MarkdownRenderChild {
   onload(): void {
     this.mounted.add(this);
     this.register(() => this.mounted.delete(this));
+    let height: number | null = null;
+    this.observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target !== this.containerEl || !this.containerEl.isConnected) continue;
+        const nextHeight = entry.borderBoxSize[0].blockSize;
+        // Native rendering measures the initial mount. Later height changes
+        // must invalidate Reading view's cached section layout explicitly.
+        if (height !== null && height !== nextHeight) this.resized(this.containerEl);
+        height = nextHeight;
+      }
+    });
+    this.observer.observe(this.containerEl, { box: "border-box" });
+    this.register(() => {
+      this.observer?.disconnect();
+      this.observer = null;
+    });
   }
 
   sync(): void {
@@ -32,8 +51,10 @@ export class ReadingCodeBlock extends MarkdownRenderChild {
       fence.info === this.fence.info) return;
     const next = this.render(fence.info, this.containerEl);
     if (!next) return;
+    this.observer?.unobserve(this.containerEl);
     this.containerEl.replaceWith(next);
     this.containerEl = next;
+    this.observer?.observe(next, { box: "border-box" });
     this.fence = fence;
   }
 }

--- a/src/reading-code-block.ts
+++ b/src/reading-code-block.ts
@@ -1,0 +1,39 @@
+import { MarkdownRenderChild, type MarkdownPostProcessorContext } from "obsidian";
+import { fencedBlockInfos } from "./block-options";
+
+/** Refresh only reused fence chrome; Obsidian owns source rendering and scrolling. */
+export class ReadingCodeBlock extends MarkdownRenderChild {
+  constructor(
+    wrapper: HTMLElement,
+    private readonly ctx: MarkdownPostProcessorContext,
+    private readonly fenceIndex: number,
+    private fence: ReturnType<typeof fencedBlockInfos>[number],
+    private readonly render: (info: string, current: HTMLElement) => HTMLElement | null,
+    private readonly mounted: Set<ReadingCodeBlock>,
+  ) {
+    super(wrapper);
+  }
+
+  onload(): void {
+    this.mounted.add(this);
+    this.register(() => this.mounted.delete(this));
+  }
+
+  sync(): void {
+    if (!this.containerEl.isConnected) return;
+    const section = this.ctx.getSectionInfo(this.containerEl);
+    if (!section) return;
+    const fence = fencedBlockInfos(section.text.split("\n")
+      .slice(section.lineStart, section.lineEnd + 1).join("\n"))[this.fenceIndex];
+    // Source/language edits belong to the native renderer. Only info-string
+    // edits can leave its HTML unchanged and require an in-place chrome update.
+    if (!fence || fence.code !== this.fence.code ||
+      fence.info.split(/\s+/)[0] !== this.fence.info.split(/\s+/)[0] ||
+      fence.info === this.fence.info) return;
+    const next = this.render(fence.info, this.containerEl);
+    if (!next) return;
+    this.containerEl.replaceWith(next);
+    this.containerEl = next;
+    this.fence = fence;
+  }
+}

--- a/tests/block-options.test.ts
+++ b/tests/block-options.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   fencedBlockInfos,
-  fencedBlockOptionsSignature,
   isStaticBlock,
   lineHighlightClass,
   parseBlockOptions,
@@ -102,19 +101,4 @@ test("backtick inline spans do not swallow later block metadata", () => {
   assert.deepEqual(fencedBlockInfos("```inline```\n\n```python static\nprint(1)\n```"), [
     { info: "python static", code: "print(1)", line: 2 },
   ]);
-});
-
-test("fence option signatures change for static edits but not code edits", () => {
-  const runnable = "```python\nprint(1)\n```";
-  const staticBlock = "```python static\nprint(1)\n```";
-  const editedCode = "```python static\nprint(2)\n```";
-
-  assert.notEqual(
-    fencedBlockOptionsSignature(runnable),
-    fencedBlockOptionsSignature(staticBlock),
-  );
-  assert.equal(
-    fencedBlockOptionsSignature(staticBlock),
-    fencedBlockOptionsSignature(editedCode),
-  );
 });

--- a/tests/code-block-widget.test.ts
+++ b/tests/code-block-widget.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { EditorView } from "@codemirror/view";
+import { CodeBlockWidget } from "../src/code-block-widget";
+
+test("equal widget replacement cleans up the mounted DOM before it is reused", (t) => {
+  const observers: { notify: () => void; disconnected: boolean }[] = [];
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver");
+  t.after(() => {
+    if (descriptor) Object.defineProperty(globalThis, "ResizeObserver", descriptor);
+    else Reflect.deleteProperty(globalThis, "ResizeObserver");
+  });
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class {
+      disconnected = false;
+      constructor(readonly notify: () => void) { observers.push(this); }
+      observe() {}
+      disconnect() { this.disconnected = true; }
+    },
+  });
+  const codeArea = new EventTarget();
+  const wrapper = {
+    isConnected: true,
+    querySelector: () => codeArea,
+  } as unknown as HTMLElement;
+  const first = { measures: 0, reveals: 0, focuses: 0 };
+  const second = { measures: 0, reveals: 0, focuses: 0 };
+  const editor = (counts: typeof first) => ({
+    requestMeasure: () => { counts.measures++; },
+    posAtDOM: () => 42,
+    dispatch: () => { counts.reveals++; },
+    focus: () => { counts.focuses++; },
+  }) as unknown as EditorView;
+  const clickCode = () => {
+    const event = new Event("mousedown", { cancelable: true });
+    Object.defineProperty(event, "button", { value: 0 });
+    codeArea.dispatchEvent(event);
+  };
+  const owner = {};
+  const mounted = new CodeBlockWidget(owner, "block", () => wrapper);
+  const replacement = new CodeBlockWidget(owner, "block", () => wrapper);
+  assert.equal(mounted.eq(replacement), true);
+  mounted.toDOM(editor(first));
+  observers[0].notify();
+  clickCode();
+  assert.deepEqual(first, { measures: 1, reveals: 1, focuses: 1 });
+
+  // CodeMirror destroys the equal replacement, which never received toDOM.
+  replacement.destroy(wrapper);
+  assert.equal(observers[0].disconnected, true);
+  clickCode();
+  assert.equal(first.reveals, 1);
+
+  const remounted = new CodeBlockWidget({}, "block", () => wrapper);
+  assert.equal(mounted.eq(remounted), false);
+  remounted.toDOM(editor(second));
+  observers[1].notify();
+  clickCode();
+  assert.deepEqual(first, { measures: 1, reveals: 1, focuses: 1 });
+  assert.deepEqual(second, { measures: 1, reveals: 1, focuses: 1 });
+  remounted.destroy(wrapper);
+  assert.equal(observers[1].disconnected, true);
+});

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -1,1 +1,8 @@
 export const Platform = { isDesktop: true };
+
+export class MarkdownRenderChild {
+  private cleanups: (() => void)[] = [];
+  constructor(public containerEl: HTMLElement) {}
+  register(cleanup: () => void): void { this.cleanups.push(cleanup); }
+  unload(): void { this.cleanups.splice(0).forEach((cleanup) => cleanup()); }
+}

--- a/tests/reading-code-block.test.ts
+++ b/tests/reading-code-block.test.ts
@@ -4,7 +4,27 @@ import type { MarkdownPostProcessorContext } from "obsidian";
 import { fencedBlockInfos } from "../src/block-options";
 import { ReadingCodeBlock } from "../src/reading-code-block";
 
-test("reused Reading blocks refresh their own options using current section positions", () => {
+test("reused Reading blocks refresh their own options and report height changes", (t) => {
+  const observed = new Set<Element>();
+  let notify: (target: Element, height: number) => void = () => assert.fail("Observer not created");
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver");
+  t.after(() => {
+    if (descriptor) Object.defineProperty(globalThis, "ResizeObserver", descriptor);
+    else Reflect.deleteProperty(globalThis, "ResizeObserver");
+  });
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class {
+      constructor(callback: (entries: ResizeObserverEntry[]) => void) {
+        notify = (target, height) => callback([
+          { target, borderBoxSize: [{ blockSize: height, inlineSize: 100 }] } as unknown as ResizeObserverEntry,
+        ]);
+      }
+      observe(target: Element) { observed.add(target); }
+      unobserve(target: Element) { observed.delete(target); }
+      disconnect() { observed.clear(); }
+    },
+  });
   const source = "```python\nprint(1)\n```\n\n```python\nprint(1)\n```";
   let section = { text: source, lineStart: 0, lineEnd: 6 };
   const replacements: HTMLElement[] = [];
@@ -15,6 +35,7 @@ test("reused Reading blocks refresh their own options using current section posi
   const next = { ...wrapper } as HTMLElement;
   const infos: string[] = [];
   const mounted = new Set<ReadingCodeBlock>();
+  const resized: HTMLElement[] = [];
   let running = false;
   const child = new ReadingCodeBlock(wrapper, {
     getSectionInfo: () => section,
@@ -22,8 +43,13 @@ test("reused Reading blocks refresh their own options using current section posi
     if (running) return null;
     infos.push(info);
     return next;
-  }, mounted);
+  }, mounted, (element) => resized.push(element));
   child.onload();
+  notify(wrapper, 11000);
+  assert.equal(resized.length, 0);
+  notify(wrapper, 41);
+  notify(wrapper, 41);
+  assert.deepEqual(resized, [wrapper]);
   child.sync();
   assert.equal(infos.length, 0);
 
@@ -38,6 +64,9 @@ test("reused Reading blocks refresh their own options using current section posi
   assert.deepEqual(infos, ["python static"]);
   assert.deepEqual(replacements, [next]);
   assert.equal(child.containerEl, next);
+  assert.deepEqual([...observed], [next]);
+  notify(next, 80);
+  assert.deepEqual(resized, [wrapper, next]);
 
   // Native rendering owns source changes; stale components must not replace it.
   section.text = section.text.replace(/print\(1\)(?=\n```$)/, "print(2)");
@@ -45,4 +74,5 @@ test("reused Reading blocks refresh their own options using current section posi
   assert.equal(replacements.length, 1);
   child.unload();
   assert.equal(mounted.size, 0);
+  assert.equal(observed.size, 0);
 });

--- a/tests/reading-code-block.test.ts
+++ b/tests/reading-code-block.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { MarkdownPostProcessorContext } from "obsidian";
+import { fencedBlockInfos } from "../src/block-options";
+import { ReadingCodeBlock } from "../src/reading-code-block";
+
+test("reused Reading blocks refresh their own options using current section positions", () => {
+  const source = "```python\nprint(1)\n```\n\n```python\nprint(1)\n```";
+  let section = { text: source, lineStart: 0, lineEnd: 6 };
+  const replacements: HTMLElement[] = [];
+  const wrapper = {
+    isConnected: true,
+    replaceWith(next: HTMLElement) { replacements.push(next); },
+  } as unknown as HTMLElement;
+  const next = { ...wrapper } as HTMLElement;
+  const infos: string[] = [];
+  const mounted = new Set<ReadingCodeBlock>();
+  let running = false;
+  const child = new ReadingCodeBlock(wrapper, {
+    getSectionInfo: () => section,
+  } as unknown as MarkdownPostProcessorContext, 1, fencedBlockInfos(source)[1], (info) => {
+    if (running) return null;
+    infos.push(info);
+    return next;
+  }, mounted);
+  child.onload();
+  child.sync();
+  assert.equal(infos.length, 0);
+
+  // The section moved and only its second, otherwise identical fence changed.
+  section = { text: "New paragraph\n\n" + source.replace(/```python(?=\nprint\(1\)\n```$)/, "```python static"), lineStart: 2, lineEnd: 8 };
+  running = true;
+  child.sync();
+  assert.equal(replacements.length, 0);
+  running = false;
+  child.sync();
+  child.sync();
+  assert.deepEqual(infos, ["python static"]);
+  assert.deepEqual(replacements, [next]);
+  assert.equal(child.containerEl, next);
+
+  // Native rendering owns source changes; stale components must not replace it.
+  section.text = section.text.replace(/print\(1\)(?=\n```$)/, "print(2)");
+  child.sync();
+  assert.equal(replacements.length, 1);
+  child.unload();
+  assert.equal(mounted.size, 0);
+});


### PR DESCRIPTION
Editing fenced blocks in a split Source/Reading view forced a whole-note preview rebuild, resetting scroll. The previous fix restored scroll after that rebuild but retained the underlying lifecycle problem. Live Preview also reused one DOM node across duplicate blocks and editor panes, allowing content to disappear or retain another editor's handlers. Reading view retained an expanded block's cached section height after collapse, leaving a blank viewport once scrolling had evicted the following sections.

Replace edit-triggered preview rebuilds and hash-based badge syncing with mounted `MarkdownRenderChild` updates using current section metadata. Fence options update locally, retaining collapse state and completed output; formatting updates wait for a running block to finish. Scope retained widget DOM to each editor and map block identities through document changes. Observe mounted widget sizes and request CodeMirror measurements for collapse, output, and embed height changes, with DOM-owned cleanup that survives equal-widget replacement. Reading view blocks also observe height changes and batch the public `View.onResize()` notification per affected pane, updating section layout without a Markdown rebuild or scroll reset.

Fixes #67.

Validation:
- Fresh disposable vault, current main baseline: adding `static` jumped Reading view from line 85 to line 19; candidate stays at line 85 and updates formatting. Baseline showed only one of two duplicate blocks per pane; candidate shows both and retains their identities through edits, insertion, and deletion.
- `node scripts/test-rendering.cjs code-suite-render-lifecycle-clean`: split-pane scroll, live options/source, formatting during execution, duplicate ownership, and repeated 500-line expansion/scroll/collapse pass in Obsidian 1.13.7. Scrolling through the expanded block first evicts following sections; after collapse, multiple paragraphs remain visible and CodeMirror's measured height matches the DOM.
- `pnpm test`: 29 JS tests and 6 Python tests pass; 2 optional graph tests skip. TypeScript and changed-file lint pass.
- Full lint encounters the pre-existing `setWarning` deprecation at `src/settings-tab.ts:269`, which is unchanged.

The Reading view blank-area regression reproduces on the previous PR head: the block shrinks to 41px while its cached section height remains 11,280px, and only one following paragraph stays rendered. The strengthened regression fails there and passes with the layout notification: cached section height returns to 57px (including margins), following paragraphs return, and scroll stays at zero.

Model/harness: GPT-6 in Codex.
